### PR TITLE
ci: adiciona workflow OSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 7 * * 1" # segunda-feira 07h UTC
+  # Necessário para publicar resultados na aba Security do GitHub
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: OSSF Scorecard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write   # publicar resultados SARIF
+      id-token: write          # autenticação sem token armazenado
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@3b1a19a80ab047f35cbb237b5bd9bdc1e14f166c # v3
+        with:
+          sarif_file: scorecard-results.sarif
+          category: ossf-scorecard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,8 @@ devem ser alterados manualmente no banco.
 ## Repositório
 
 - **Nome:** `onde-tem-buteco`
-- **Organização:** `gianimprotta`
-- **URL:** `https://github.com/gianimprotta/onde-tem-buteco`
+- **Organização:** `gianimpronta`
+- **URL:** `https://github.com/gianimpronta/onde-tem-buteco`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 ### 1. Clone o repositório
 
 ```bash
-git clone https://github.com/gianimprotta/onde-tem-buteco.git
+git clone https://github.com/gianimpronta/onde-tem-buteco.git
 cd onde-tem-buteco
 ```
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=gianimprotta_onde-tem-buteco
+sonar.projectKey=gianimpronta_onde-tem-buteco
 sonar.organization=gianimpronta
 
 sonar.projectName=Onde Tem Buteco


### PR DESCRIPTION
## Resumo

- Adiciona `.github/workflows/scorecard.yml` com o workflow oficial da OSSF
- Publica resultados como SARIF na aba **Security → Code scanning** do GitHub
- Roda a cada push em `main` e toda segunda-feira 07h UTC
- Todas as Actions pinadas por SHA

## Como testar

Após merge, acessar: **Security → Code scanning alerts** para ver os resultados do Scorecard diretamente no GitHub.