### PR TITLE
feat: adiciona filtros na listagem de botecos

### DIFF
--- a/apps/web/app/(public)/butecos/page.tsx
+++ b/apps/web/app/(public)/butecos/page.tsx
@@ -42,10 +42,9 @@ export default async function ButecosPage({
   const activeFiltersCount = countActiveButecoFilters(filters);
   const cidadeOptions = cidades.map(({ cidade }) => cidade);
   const bairroOptions = bairros.flatMap(({ bairro }) => (bairro ? [bairro] : []));
+  const activeFiltersSuffix = activeFiltersCount === 1 ? "" : "s";
   const activeFiltersLabel =
-    activeFiltersCount > 0
-      ? ` com ${activeFiltersCount} filtro${activeFiltersCount === 1 ? "" : "s"}`
-      : "";
+    activeFiltersCount > 0 ? ` com ${activeFiltersCount} filtro${activeFiltersSuffix}` : "";
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6">

--- a/apps/web/app/(public)/butecos/page.tsx
+++ b/apps/web/app/(public)/butecos/page.tsx
@@ -1,47 +1,177 @@
+import Link from "next/link";
+import {
+  buildButecoWhere,
+  countActiveButecoFilters,
+  normalizeButecoFilters,
+} from "@/lib/buteco-filters";
 import { prisma } from "@/lib/prisma";
 
 export default async function ButecosPage({
   searchParams,
 }: Readonly<{ searchParams: Promise<{ cidade?: string; bairro?: string; q?: string }> }>) {
-  const { cidade, bairro, q } = await searchParams;
+  const filters = normalizeButecoFilters(await searchParams);
 
-  const butecos = await prisma.buteco.findMany({
-    where: {
-      ...(cidade ? { cidade } : {}),
-      ...(bairro ? { bairro } : {}),
-      ...(q ? { nome: { contains: q, mode: "insensitive" } } : {}),
-    },
-    orderBy: { nome: "asc" },
-    select: {
-      slug: true,
-      nome: true,
-      cidade: true,
-      bairro: true,
-      petiscoNome: true,
-      fotoUrl: true,
-    },
-  });
+  const [cidades, bairros, butecos] = await Promise.all([
+    prisma.buteco.findMany({
+      select: { cidade: true },
+      distinct: ["cidade"],
+      orderBy: { cidade: "asc" },
+    }),
+    prisma.buteco.findMany({
+      where: {
+        bairro: { not: null },
+        ...(filters.cidade ? { cidade: filters.cidade } : {}),
+      },
+      select: { bairro: true },
+      distinct: ["bairro"],
+      orderBy: { bairro: "asc" },
+    }),
+    prisma.buteco.findMany({
+      where: buildButecoWhere(filters),
+      orderBy: { nome: "asc" },
+      select: {
+        slug: true,
+        nome: true,
+        cidade: true,
+        bairro: true,
+        petiscoNome: true,
+      },
+    }),
+  ]);
+
+  const activeFiltersCount = countActiveButecoFilters(filters);
+  const cidadeOptions = cidades.map(({ cidade }) => cidade);
+  const bairroOptions = bairros.flatMap(({ bairro }) => (bairro ? [bairro] : []));
 
   return (
-    <main className="max-w-4xl mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-6">Botecos</h1>
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6">
+      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+              Explorar botecos
+            </p>
+            <h1 className="mt-1 text-3xl font-black tracking-tight text-zinc-900">Botecos</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-zinc-600 sm:text-base">
+              Refine a lista por cidade, bairro ou busca textual para encontrar um petisco ou
+              boteco com mais rapidez.
+            </p>
+          </div>
+
+          <div className="inline-flex items-center rounded-full bg-zinc-100 px-4 py-2 text-sm font-semibold text-zinc-700">
+            {butecos.length} resultado{butecos.length === 1 ? "" : "s"}
+            {activeFiltersCount > 0 ? ` com ${activeFiltersCount} filtro${activeFiltersCount === 1 ? "" : "s"}` : ""}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <form className="grid gap-4 lg:grid-cols-[1.2fr_1fr_1fr_auto_auto] lg:items-end">
+          <label className="flex flex-col gap-2">
+            <span className="text-sm font-semibold text-zinc-800">Buscar</span>
+            <input
+              name="q"
+              defaultValue={filters.q ?? ""}
+              placeholder="Nome do buteco ou petisco"
+              className="rounded-2xl border border-zinc-200 px-4 py-3 text-sm text-zinc-900 outline-none transition focus:border-amber-400"
+            />
+          </label>
+
+          <label className="flex flex-col gap-2">
+            <span className="text-sm font-semibold text-zinc-800">Cidade</span>
+            <select
+              name="cidade"
+              defaultValue={filters.cidade ?? ""}
+              className="rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 outline-none transition focus:border-amber-400"
+            >
+              <option value="">Todas as cidades</option>
+              {cidadeOptions.map((cidade) => (
+                <option key={cidade} value={cidade}>
+                  {cidade}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-2">
+            <span className="text-sm font-semibold text-zinc-800">Bairro</span>
+            <select
+              name="bairro"
+              defaultValue={filters.bairro ?? ""}
+              className="rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 outline-none transition focus:border-amber-400 disabled:cursor-not-allowed disabled:bg-zinc-100 disabled:text-zinc-400"
+              disabled={bairroOptions.length === 0}
+            >
+              <option value="">Todos os bairros</option>
+              {bairroOptions.map((bairro) => (
+                <option key={bairro} value={bairro}>
+                  {bairro}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <button
+            type="submit"
+            className="rounded-2xl bg-amber-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-amber-600"
+          >
+            Aplicar filtros
+          </button>
+
+          <Link
+            href="/butecos"
+            className="rounded-2xl border border-zinc-200 px-5 py-3 text-center text-sm font-semibold text-zinc-700 transition hover:border-amber-300 hover:bg-amber-50"
+          >
+            Limpar
+          </Link>
+        </form>
+
+        {filters.cidade && bairroOptions.length === 0 ? (
+          <p className="mt-4 text-sm text-zinc-500">
+            Ainda nÃ£o existem bairros cadastrados para a cidade selecionada.
+          </p>
+        ) : null}
+      </section>
+
       {butecos.length === 0 ? (
-        <p className="text-zinc-500">Nenhum buteco encontrado.</p>
+        <section className="rounded-3xl border border-dashed border-zinc-300 bg-zinc-50 px-6 py-12 text-center">
+          <h2 className="text-xl font-bold text-zinc-900">Nenhum boteco encontrado</h2>
+          <p className="mt-2 text-sm leading-relaxed text-zinc-600">
+            Tente ajustar os filtros ou limpar a busca para ver mais participantes.
+          </p>
+          <div className="mt-5 flex flex-col justify-center gap-3 sm:flex-row">
+            <Link
+              href="/butecos"
+              className="rounded-full bg-amber-500 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-amber-600"
+            >
+              Limpar filtros
+            </Link>
+            <Link
+              href="/"
+              className="rounded-full border border-zinc-200 px-5 py-2.5 text-sm font-semibold text-zinc-700 transition hover:border-amber-300 hover:bg-amber-50"
+            >
+              Voltar para a home
+            </Link>
+          </div>
+        </section>
       ) : (
         <ul className="grid gap-4 sm:grid-cols-2">
           {butecos.map((b) => (
             <li key={b.slug}>
-              <a
+              <Link
                 href={`/butecos/${b.slug}`}
-                className="block p-4 rounded-xl border border-zinc-200 hover:border-amber-400 transition-colors"
+                className="block rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-amber-400"
               >
-                <p className="font-semibold">{b.nome}</p>
-                <p className="text-sm text-zinc-500">
+                <p className="text-lg font-bold text-zinc-900">{b.nome}</p>
+                <p className="mt-1 text-sm text-zinc-500">
                   {b.bairro ? `${b.bairro}, ` : ""}
                   {b.cidade}
                 </p>
-                {b.petiscoNome && <p className="text-sm text-amber-600 mt-1">{b.petiscoNome}</p>}
-              </a>
+                {b.petiscoNome ? (
+                  <p className="mt-3 text-sm font-medium text-amber-700">{b.petiscoNome}</p>
+                ) : (
+                  <p className="mt-3 text-sm text-zinc-400">Petisco ainda nÃ£o informado</p>
+                )}
+              </Link>
             </li>
           ))}
         </ul>

--- a/apps/web/app/(public)/butecos/page.tsx
+++ b/apps/web/app/(public)/butecos/page.tsx
@@ -42,6 +42,10 @@ export default async function ButecosPage({
   const activeFiltersCount = countActiveButecoFilters(filters);
   const cidadeOptions = cidades.map(({ cidade }) => cidade);
   const bairroOptions = bairros.flatMap(({ bairro }) => (bairro ? [bairro] : []));
+  const activeFiltersLabel =
+    activeFiltersCount > 0
+      ? ` com ${activeFiltersCount} filtro${activeFiltersCount === 1 ? "" : "s"}`
+      : "";
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6">
@@ -53,14 +57,14 @@ export default async function ButecosPage({
             </p>
             <h1 className="mt-1 text-3xl font-black tracking-tight text-zinc-900">Botecos</h1>
             <p className="mt-2 max-w-2xl text-sm leading-relaxed text-zinc-600 sm:text-base">
-              Refine a lista por cidade, bairro ou busca textual para encontrar um petisco ou
-              boteco com mais rapidez.
+              Refine a lista por cidade, bairro ou busca textual para encontrar um petisco ou boteco
+              com mais rapidez.
             </p>
           </div>
 
           <div className="inline-flex items-center rounded-full bg-zinc-100 px-4 py-2 text-sm font-semibold text-zinc-700">
             {butecos.length} resultado{butecos.length === 1 ? "" : "s"}
-            {activeFiltersCount > 0 ? ` com ${activeFiltersCount} filtro${activeFiltersCount === 1 ? "" : "s"}` : ""}
+            {activeFiltersLabel}
           </div>
         </div>
       </section>

--- a/apps/web/lib/__tests__/buteco-filters.test.ts
+++ b/apps/web/lib/__tests__/buteco-filters.test.ts
@@ -1,0 +1,52 @@
+import {
+  buildButecoWhere,
+  countActiveButecoFilters,
+  normalizeButecoFilters,
+} from "@/lib/buteco-filters";
+
+describe("buteco-filters", () => {
+  it("trims filter values and removes empty ones", () => {
+    expect(
+      normalizeButecoFilters({
+        cidade: "  Belo Horizonte  ",
+        bairro: "   ",
+        q: "  torresmo ",
+      })
+    ).toEqual({
+      cidade: "Belo Horizonte",
+      bairro: undefined,
+      q: "torresmo",
+    });
+  });
+
+  it("builds prisma where clause with text search on buteco and petisco names", () => {
+    expect(
+      buildButecoWhere({
+        cidade: "Belo Horizonte",
+        bairro: "Centro",
+        q: "torresmo",
+      })
+    ).toEqual({
+      cidade: "Belo Horizonte",
+      bairro: "Centro",
+      OR: [
+        { nome: { contains: "torresmo", mode: "insensitive" } },
+        { petiscoNome: { contains: "torresmo", mode: "insensitive" } },
+      ],
+    });
+  });
+
+  it("returns empty where clause when there are no active filters", () => {
+    expect(buildButecoWhere({ cidade: "   ", bairro: "", q: undefined })).toEqual({});
+  });
+
+  it("counts only active filters", () => {
+    expect(
+      countActiveButecoFilters({
+        cidade: "Belo Horizonte",
+        bairro: "",
+        q: "feijoada",
+      })
+    ).toBe(2);
+  });
+});

--- a/apps/web/lib/buteco-filters.ts
+++ b/apps/web/lib/buteco-filters.ts
@@ -1,0 +1,49 @@
+import type { Prisma } from "@/app/generated/prisma/client";
+
+export type ButecoSearchFilters = {
+  bairro?: string;
+  cidade?: string;
+  q?: string;
+};
+
+function normalizeFilterValue(value?: string): string | undefined {
+  const trimmedValue = value?.trim();
+
+  if (!trimmedValue) {
+    return undefined;
+  }
+
+  return trimmedValue;
+}
+
+export function normalizeButecoFilters(filters: ButecoSearchFilters): ButecoSearchFilters {
+  return {
+    cidade: normalizeFilterValue(filters.cidade),
+    bairro: normalizeFilterValue(filters.bairro),
+    q: normalizeFilterValue(filters.q),
+  };
+}
+
+export function buildButecoWhere(filters: ButecoSearchFilters): Prisma.ButecoWhereInput {
+  const normalizedFilters = normalizeButecoFilters(filters);
+
+  return {
+    ...(normalizedFilters.cidade ? { cidade: normalizedFilters.cidade } : {}),
+    ...(normalizedFilters.bairro ? { bairro: normalizedFilters.bairro } : {}),
+    ...(normalizedFilters.q
+      ? {
+          OR: [
+            { nome: { contains: normalizedFilters.q, mode: "insensitive" } },
+            { petiscoNome: { contains: normalizedFilters.q, mode: "insensitive" } },
+          ],
+        }
+      : {}),
+  };
+}
+
+export function countActiveButecoFilters(filters: ButecoSearchFilters): number {
+  const normalizedFilters = normalizeButecoFilters(filters);
+
+  return [normalizedFilters.cidade, normalizedFilters.bairro, normalizedFilters.q].filter(Boolean)
+    .length;
+}


### PR DESCRIPTION
## Resumo
- adiciona filtros de cidade, bairro e busca textual na rota /butecos
- extrai a lógica de filtros para um helper testável
- melhora o estado vazio e a navegação de limpeza dos filtros

## Testes
- pnpm test -- --runInBand
- pnpm exec eslint 'app/(public)/butecos/page.tsx' 'lib/buteco-filters.ts' 'lib/__tests__/buteco-filters.test.ts'
- pnpm exec next typegen
- pnpm exec tsc --noEmit

Refs #43