### PR TITLE
Fix buteco filters and production runtime

### DIFF
--- a/.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.ps1
+++ b/.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.ps1
@@ -1,0 +1,42 @@
+param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string]$InputData
+)
+
+try {
+    $input = $InputData | ConvertFrom-Json -ErrorAction Stop
+} catch {
+    exit 0
+}
+
+$toolName = $input.tool_name
+$filePath = $input.tool_input.file_path
+
+if ($toolName -ne "Read" -or [string]::IsNullOrEmpty($filePath) -or -not (Test-Path $filePath)) {
+    exit 0
+}
+
+if (-not (Get-Command sonar -ErrorAction SilentlyContinue)) {
+    exit 0
+}
+
+try {
+    & sonar analyze secrets $filePath | Out-Null
+    $exitCode = $LASTEXITCODE
+} catch {
+    exit 0
+}
+
+if ($exitCode -eq 51) {
+    $reason = "Sonar detected secrets in file: $filePath"
+    $response = @{
+        hookSpecificOutput = @{
+            hookEventName = "PreToolUse"
+            permissionDecision = "deny"
+            permissionDecisionReason = $reason
+        }
+    } | ConvertTo-Json
+    Write-Host $response
+}
+
+exit 0

--- a/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.ps1
+++ b/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.ps1
@@ -1,0 +1,48 @@
+param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string]$InputData
+)
+
+try {
+    $input = $InputData | ConvertFrom-Json -ErrorAction Stop
+} catch {
+    exit 0
+}
+
+$prompt = $input.prompt
+
+if ([string]::IsNullOrEmpty($prompt)) {
+    exit 0
+}
+
+if (-not (Get-Command sonar -ErrorAction SilentlyContinue)) {
+    exit 0
+}
+
+# Create temporary file with prompt content (stdin is already occupied by hook input)
+$tempFile = [System.IO.Path]::GetTempFileName()
+
+try {
+    $prompt | Set-Content -Path $tempFile -NoNewline -Encoding UTF8
+
+    # Scan prompt for secrets (using file instead of stdin pipe)
+    & sonar analyze secrets $tempFile | Out-Null
+    $exitCode = $LASTEXITCODE
+} catch {
+    $exitCode = 0
+} finally {
+    if (Test-Path $tempFile) {
+        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($exitCode -eq 51) {
+    $reason = "Sonar detected secrets in prompt"
+    $response = @{
+        decision = "block"
+        reason = $reason
+    } | ConvertTo-Json
+    Write-Host $response
+}
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -File .claude/hooks/sonar-secrets/build-scripts/pretool-secrets.ps1",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -File .claude/hooks/sonar-secrets/build-scripts/prompt-secrets.ps1",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,289 @@
+# AGENTS.md — onde-tem-buteco
+
+Guia de desenvolvimento para agentes de IA e colaboradores do projeto.
+Leia este arquivo inteiro antes de escrever qualquer código.
+
+---
+
+## Visão geral do projeto
+
+**Onde Tem Buteco** é um web app que complementa o site oficial do concurso
+Comida di Buteco (comidadibuteco.com.br), preenchendo lacunas de UX como:
+mapa interativo, filtro por bairro, montagem de roteiro e conta de usuário
+com favoritos e histórico de visitas.
+
+Os dados são obtidos exclusivamente via scraping do site oficial e nunca
+devem ser alterados manualmente no banco.
+
+---
+
+## Repositório
+
+- **Nome:** `onde-tem-buteco`
+- **Organização:** `gianimpronta`
+- **URL:** `https://github.com/gianimpronta/onde-tem-buteco`
+
+---
+
+## Stack
+
+| Camada | Tecnologia |
+|---|---|
+| Framework | Next.js 16 (App Router) + TypeScript |
+| Estilização | Tailwind CSS |
+| ORM | Prisma |
+| Banco de dados | Vercel Postgres (Neon) |
+| Autenticação | NextAuth.js v5 (Google OAuth) |
+| Mapa | Leaflet.js |
+| Scraper | Python 3.12 + BeautifulSoup + psycopg2 |
+| CI/CD | GitHub Actions |
+| Hospedagem | Vercel |
+
+---
+
+## Estrutura do repositório
+
+```
+onde-tem-buteco/
+├── apps/
+│   └── web/                          # Aplicação Next.js
+│       ├── app/
+│       │   ├── (public)/
+│       │   │   ├── page.tsx                    # Home com mapa
+│       │   │   ├── butecos/
+│       │   │   │   ├── page.tsx                # Listagem com filtros
+│       │   │   │   └── [slug]/page.tsx         # Detalhe do buteco
+│       │   ├── (auth)/
+│       │   │   ├── login/page.tsx
+│       │   │   └── cadastro/page.tsx
+│       │   ├── (private)/
+│       │   │   └── minha-conta/page.tsx        # Favoritos + histórico
+│       │   └── api/
+│       │       ├── auth/[...nextauth]/route.ts
+│       │       └── butecos/route.ts
+│       ├── components/
+│       │   ├── ui/                             # Componentes base
+│       │   ├── mapa/                           # Componentes Leaflet
+│       │   └── butecos/                        # Cards, filtros, listagem
+│       ├── lib/
+│       │   ├── prisma.ts                       # Singleton do Prisma client
+│       │   └── auth.ts                         # Configuração NextAuth
+│       └── prisma/
+│           └── schema.prisma
+└── scraper/                          # Script Python isolado
+    ├── main.py
+    ├── requirements.txt
+    └── .github/
+        └── workflows/
+            └── scraper.yml
+```
+
+---
+
+## Schema do banco de dados
+
+```prisma
+model Buteco {
+  id          String   @id @default(cuid())
+  slug        String   @unique
+  nome        String
+  cidade      String
+  bairro      String?
+  endereco    String
+  telefone    String?
+  horario     String?
+  petiscoNome String?
+  petiscoDesc String?
+  fotoUrl     String?
+  lat         Float?
+  lng         Float?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  favoritos   Favorito[]
+  visitas     Visita[]
+}
+
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  name      String?
+  image     String?
+  createdAt DateTime @default(now())
+
+  favoritos Favorito[]
+  visitas   Visita[]
+}
+
+model Favorito {
+  id        String   @id @default(cuid())
+  userId    String
+  butecoId  String
+  createdAt DateTime @default(now())
+
+  user      User     @relation(fields: [userId], references: [id])
+  buteco    Buteco   @relation(fields: [butecoId], references: [id])
+
+  @@unique([userId, butecoId])
+}
+
+model Visita {
+  id          String   @id @default(cuid())
+  userId      String
+  butecoId    String
+  visitadoEm DateTime @default(now())
+
+  user      User     @relation(fields: [userId], references: [id])
+  buteco    Buteco   @relation(fields: [butecoId], references: [id])
+
+  @@unique([userId, butecoId])
+}
+```
+
+---
+
+## Variáveis de ambiente
+
+```bash
+# .env.local (nunca commitar)
+DATABASE_URL=
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+```
+
+O scraper usa apenas `DATABASE_URL`, injetada via GitHub Actions Secret.
+
+---
+
+## Scraper
+
+- **Fonte:** `https://comidadibuteco.com.br/butecos/`
+- **Frequência:** Toda segunda-feira às 06h (GitHub Actions cron)
+- **Estratégia:** Upsert por `slug` — nunca deletar registros existentes
+- **Rate limit:** `time.sleep(0.5)` entre requisições para respeitar o servidor
+- **Geocodificação:** Nominatim (OpenStreetMap) — gratuito, sem chave de API
+
+### Rodar manualmente
+
+```bash
+cd scraper
+pip install -r requirements.txt
+DATABASE_URL=<url> python main.py
+```
+
+---
+
+## Convenções de código
+
+### Geral
+- TypeScript strict mode sempre ativado — sem `any`
+- Funções e variáveis em `camelCase`
+- Componentes React em `PascalCase`
+- Arquivos de componente em `kebab-case.tsx`
+- Sem comentários óbvios — o código deve ser autodescritivo
+
+### Next.js
+- Preferir Server Components por padrão
+- Client Components (`"use client"`) apenas quando necessário (interatividade, hooks)
+- Dados sempre buscados no servidor via Prisma — nunca expor o client do Prisma no browser
+- Rotas de API apenas para mutações (POST/DELETE de favoritos e visitas)
+
+### Prisma
+- Sempre usar o singleton de `lib/prisma.ts`
+- Nunca usar `prisma.$queryRaw` — usar a API do Prisma
+- Migrations via `prisma migrate dev` em desenvolvimento
+
+### Tailwind
+- Sem CSS customizado — usar apenas classes utilitárias do Tailwind
+- Componentes reutilizáveis extraídos para `components/ui/`
+
+---
+
+## Fluxo de desenvolvimento
+
+### Antes de começar qualquer tarefa
+1. Ler este arquivo
+2. Verificar se existe issue ou task relacionada
+3. Criar branch a partir de `main` com nome descritivo: `feat/mapa-leaflet`, `fix/filtro-bairro`
+
+### Commits
+Seguir Conventional Commits:
+```
+feat: adiciona mapa interativo com Leaflet
+fix: corrige filtro por bairro no Rio
+chore: atualiza dependências
+docs: atualiza AGENTS.md com instruções do scraper
+```
+
+### Pull Requests
+- PRs pequenos e focados — uma funcionalidade por PR
+- Descrever o que foi feito e como testar
+- Vercel cria preview deploy automático por PR
+
+---
+
+## Fases do MVP
+
+### Fase 1 — Dados ✅ (base)
+- [ ] Setup Next.js 16 + TypeScript + Tailwind + Prisma
+- [ ] Configurar Vercel Postgres
+- [ ] Rodar scraper manualmente para popular o banco
+- [ ] Migrations iniciais
+
+### Fase 2 — Leitura
+- [ ] Listagem de butecos com filtro por cidade e bairro
+- [ ] Busca por nome
+- [ ] Página de detalhe do buteco
+- [ ] Mapa interativo com Leaflet
+
+### Fase 3 — Usuário
+- [ ] Google OAuth via NextAuth
+- [ ] Favoritar buteco
+- [ ] Marcar como visitado
+- [ ] Página "Minha Conta" com favoritos e histórico
+
+### Fase 4 — Produção
+- [ ] SEO básico (metadata, Open Graph, sitemap.xml)
+- [ ] Deploy na Vercel
+- [ ] Configurar GitHub Actions cron do scraper
+- [ ] Monitoramento de erros (Sentry ou Vercel Analytics)
+
+---
+
+## Repositório público — cuidados
+
+Este repositório é **público**. Qualquer pessoa pode ler o código.
+
+- Nunca commitar `.env.local`, `.env` ou qualquer arquivo com credenciais reais
+- Manter `.env.example` sempre atualizado com todas as chaves necessárias (valores vazios)
+- O scraper é visível publicamente — manter `time.sleep` e não fazer scraping agressivo
+- Este projeto é **fan-made**, sem fins comerciais. Os dados pertencem ao Comida di Buteco
+- Não incluir tokens, senhas ou URLs de banco de dados em issues, PRs ou comentários de código
+- Secrets de produção ficam **apenas** nas configurações da Vercel e nos GitHub Actions Secrets
+
+---
+
+## Arquivos obrigatórios no repositório
+
+| Arquivo | Propósito |
+|---|---|
+| `.gitignore` | Ignorar `.env.local`, `.env`, `node_modules/`, `.next/`, `__pycache__/` |
+| `.env.example` | Documentar todas as variáveis necessárias com valores vazios |
+| `README.md` | Descrição, como rodar localmente, stack e créditos |
+| `LICENSE` | MIT — uso livre com atribuição |
+| `AGENTS.md` | Este arquivo — guia para agentes de IA e colaboradores |
+
+---
+
+## O que NÃO fazer
+
+- Não editar dados de butecos manualmente no banco — a fonte da verdade é o scraper
+- Não usar `prisma.$queryRaw` ou SQL direto
+- Não criar CSS customizado fora do Tailwind
+- Não commitar `.env.local` ou qualquer secret
+- Não fazer scraping sem `time.sleep` — respeitar o servidor de origem
+- Não usar `any` no TypeScript
+- Não criar Server Actions para leituras — usar Server Components diretamente
+- Não incluir credenciais reais em nenhum arquivo versionado, mesmo que "temporariamente"

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -1,15 +1,8 @@
-import dynamicImport from "next/dynamic";
 import Link from "next/link";
+import { MapaButecosShell } from "@/components/mapa/mapa-butecos-shell";
 import { prisma } from "@/lib/prisma";
 
 export const dynamic = "force-dynamic";
-
-const MapaButecos = dynamicImport(
-  () => import("@/components/mapa/mapa-butecos").then((module) => module.MapaButecos),
-  {
-    ssr: false,
-  }
-);
 
 type ButecoComCoordenada = {
   slug: string;
@@ -99,7 +92,7 @@ export default async function Home() {
       </section>
 
       <section aria-label="Mapa de botecos" className="pb-6">
-        <MapaButecos butecos={butecosComMapa} />
+        <MapaButecosShell butecos={butecosComMapa} />
       </section>
     </main>
   );

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -1,8 +1,15 @@
+import dynamicImport from "next/dynamic";
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
-import { MapaButecos } from "@/components/mapa/mapa-butecos";
 
 export const dynamic = "force-dynamic";
+
+const MapaButecos = dynamicImport(
+  () => import("@/components/mapa/mapa-butecos").then((module) => module.MapaButecos),
+  {
+    ssr: false,
+  }
+);
 
 type ButecoComCoordenada = {
   slug: string;

--- a/apps/web/components/mapa/mapa-butecos-shell.tsx
+++ b/apps/web/components/mapa/mapa-butecos-shell.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const MapaButecos = dynamic(
+  () => import("@/components/mapa/mapa-butecos").then((module) => module.MapaButecos),
+  {
+    ssr: false,
+  }
+);
+
+type ButecoMapa = {
+  slug: string;
+  nome: string;
+  bairro: string | null;
+  lat: number;
+  lng: number;
+};
+
+type MapaButecosShellProps = {
+  butecos: ButecoMapa[];
+};
+
+export function MapaButecosShell({ butecos }: Readonly<MapaButecosShellProps>) {
+  return <MapaButecos butecos={butecos} />;
+}

--- a/apps/web/lib/prisma.ts
+++ b/apps/web/lib/prisma.ts
@@ -27,6 +27,8 @@ function createPool(connectionString: string) {
   const poolConfig: PoolConfig = { connectionString };
 
   if (sslMode !== "disable") {
+    connectionUrl.searchParams.delete("sslmode");
+    poolConfig.connectionString = connectionUrl.toString();
     poolConfig.ssl = { rejectUnauthorized: false };
   }
 

--- a/apps/web/lib/prisma.ts
+++ b/apps/web/lib/prisma.ts
@@ -6,10 +6,15 @@ const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
 function createPrismaClient() {
   const connectionString =
-    process.env.DATABASE_URL ?? process.env.POSTGRES_URL ?? process.env.POSTGRES_PRISMA_URL;
+    process.env.POSTGRES_URL_NON_POOLING ??
+    process.env.POSTGRES_URL ??
+    process.env.POSTGRES_PRISMA_URL ??
+    process.env.DATABASE_URL;
 
   if (!connectionString) {
-    throw new Error("DATABASE_URL, POSTGRES_URL ou POSTGRES_PRISMA_URL precisam estar definidos.");
+    throw new Error(
+      "POSTGRES_URL_NON_POOLING, POSTGRES_URL, POSTGRES_PRISMA_URL ou DATABASE_URL precisam estar definidos."
+    );
   }
 
   const adapter = new PrismaPg(createPool(connectionString));

--- a/apps/web/lib/prisma.ts
+++ b/apps/web/lib/prisma.ts
@@ -4,7 +4,14 @@ import { PrismaClient } from "@/app/generated/prisma/client";
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
 function createPrismaClient() {
-  const adapter = new PrismaPg({ connectionString: process.env.POSTGRES_PRISMA_URL! });
+  const connectionString =
+    process.env.DATABASE_URL ?? process.env.POSTGRES_URL ?? process.env.POSTGRES_PRISMA_URL;
+
+  if (!connectionString) {
+    throw new Error("DATABASE_URL, POSTGRES_URL ou POSTGRES_PRISMA_URL precisam estar definidos.");
+  }
+
+  const adapter = new PrismaPg({ connectionString });
   return new PrismaClient({ adapter });
 }
 

--- a/apps/web/lib/prisma.ts
+++ b/apps/web/lib/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool, type PoolConfig } from "pg";
 import { PrismaClient } from "@/app/generated/prisma/client";
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
@@ -11,8 +12,20 @@ function createPrismaClient() {
     throw new Error("DATABASE_URL, POSTGRES_URL ou POSTGRES_PRISMA_URL precisam estar definidos.");
   }
 
-  const adapter = new PrismaPg({ connectionString });
+  const adapter = new PrismaPg(createPool(connectionString));
   return new PrismaClient({ adapter });
+}
+
+function createPool(connectionString: string) {
+  const connectionUrl = new URL(connectionString);
+  const sslMode = connectionUrl.searchParams.get("sslmode");
+  const poolConfig: PoolConfig = { connectionString };
+
+  if (sslMode !== "disable") {
+    poolConfig.ssl = { rejectUnauthorized: false };
+  }
+
+  return new Pool(poolConfig);
 }
 
 export const prisma = globalForPrisma.prisma ?? createPrismaClient();

--- a/docs/superpowers/plans/2026-04-11-scraper.md
+++ b/docs/superpowers/plans/2026-04-11-scraper.md
@@ -1,0 +1,443 @@
+# Scraper Python Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Criar script Python que coleta dados de ~1100 butecos do comidadibuteco.com.br e faz upsert no PostgreSQL do Supabase.
+
+**Architecture:** Script único `scraper/main.py` com 4 funções: `get_slugs` (paginação), `scrape_buteco` (detalhe por slug), `upsert_buteco` (INSERT ON CONFLICT), e `main` (orquestração). Conexão direta via psycopg2 com `POSTGRES_URL_NON_POOLING`.
+
+**Tech Stack:** Python 3.12, requests, BeautifulSoup4, psycopg2-binary, python-dotenv
+
+---
+
+## File Map
+
+| Arquivo | Ação | Responsabilidade |
+|---|---|---|
+| `scraper/main.py` | Criar | Script completo do scraper |
+| `scraper/requirements.txt` | Criar | Dependências Python |
+| `scraper/.env.example` | Criar | Documentação de variáveis de ambiente |
+| `.github/workflows/scraper.yml` | Criar | Cron job GitHub Actions |
+
+---
+
+### Task 1: Estrutura inicial e requirements
+
+**Files:**
+- Create: `scraper/requirements.txt`
+- Create: `scraper/.env.example`
+- Create: `scraper/main.py` (esqueleto)
+
+- [ ] **Step 1: Criar `scraper/requirements.txt`**
+
+```
+requests==2.32.3
+beautifulsoup4==4.12.3
+psycopg2-binary==2.9.10
+python-dotenv==1.0.1
+```
+
+- [ ] **Step 2: Criar `scraper/.env.example`**
+
+```
+POSTGRES_URL_NON_POOLING=
+```
+
+- [ ] **Step 3: Criar esqueleto de `scraper/main.py`**
+
+```python
+import os
+import time
+import re
+import requests
+import psycopg2
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BASE_URL = "https://comidadibuteco.com.br"
+HEADERS = {"User-Agent": "onde-tem-buteco-scraper/1.0"}
+SLEEP = 0.5
+
+
+def get_slugs(page: int) -> list[str]:
+    pass
+
+
+def scrape_buteco(slug: str) -> dict:
+    pass
+
+
+def upsert_buteco(conn, data: dict) -> None:
+    pass
+
+
+def main() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Verificar que o arquivo executa sem erro de sintaxe**
+
+```bash
+cd scraper
+python -c "import main; print('ok')"
+```
+Esperado: `ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scraper/
+git commit -m "chore: estrutura inicial do scraper"
+```
+
+---
+
+### Task 2: Implementar `get_slugs`
+
+**Files:**
+- Modify: `scraper/main.py`
+
+- [ ] **Step 1: Implementar `get_slugs`**
+
+Substitua o `pass` em `get_slugs`:
+
+```python
+def get_slugs(page: int) -> list[str]:
+    url = f"{BASE_URL}/butecos/page/{page}/"
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=10)
+    except requests.RequestException as e:
+        print(f"  erro ao buscar página {page}: {e}")
+        return []
+
+    if resp.status_code == 404:
+        return []
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    slugs = []
+    for a in soup.select("a[href*='/buteco/']"):
+        href = a["href"]
+        match = re.search(r"/buteco/([^/]+)/?$", href)
+        if match:
+            slug = match.group(1)
+            if slug not in slugs:
+                slugs.append(slug)
+    return slugs
+```
+
+- [ ] **Step 2: Testar manualmente**
+
+```bash
+cd scraper
+python -c "from main import get_slugs; s = get_slugs(1); print(len(s), s[:3])"
+```
+Esperado: `12 ['1-poco-loco', ...]` (ou similar com 12 slugs)
+
+- [ ] **Step 3: Testar página inexistente**
+
+```bash
+python -c "from main import get_slugs; print(get_slugs(9999))"
+```
+Esperado: `[]`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scraper/main.py
+git commit -m "feat(scraper): implementa get_slugs com paginação"
+```
+
+---
+
+### Task 3: Implementar `scrape_buteco`
+
+**Files:**
+- Modify: `scraper/main.py`
+
+- [ ] **Step 1: Implementar `scrape_buteco`**
+
+Substitua o `pass` em `scrape_buteco`:
+
+```python
+def scrape_buteco(slug: str) -> dict:
+    url = f"{BASE_URL}/buteco/{slug}/"
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        print(f"  erro ao buscar {slug}: {e}")
+        return {}
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    nome_tag = soup.select_one("h1.section-title")
+    nome = nome_tag.get_text(strip=True) if nome_tag else ""
+
+    foto_tag = soup.select_one("img.img-single")
+    foto_url = foto_tag["src"] if foto_tag else None
+
+    section = soup.select_one(".section-text")
+    petisco_nome = None
+    petisco_desc = None
+    endereco = None
+    telefone = None
+    horario = None
+
+    if section:
+        paragraphs = section.find_all("p")
+        for i, p in enumerate(paragraphs):
+            bold = p.find("b")
+            if not bold:
+                continue
+            label = bold.get_text(strip=True).lower().rstrip(":")
+            value = p.get_text(strip=True)[len(bold.get_text(strip=True)):].strip().lstrip(":").strip()
+
+            if label == "endereço" or label == "endereco":
+                endereco = value
+            elif label == "telefone":
+                telefone = value
+            elif label in ("horario", "horário"):
+                horario = value
+            elif i == 0:
+                petisco_nome = bold.get_text(strip=True)
+                petisco_desc = value if value else None
+
+    cidade = None
+    bairro = None
+    if endereco:
+        parts = [p.strip() for p in endereco.split(",")]
+        # Remove estado (UF) se presente na última parte
+        last = parts[-1].strip()
+        if re.match(r"^[A-Z]{2}$", last):
+            parts = parts[:-1]
+        cidade = parts[-1].strip() if parts else None
+        bairro = parts[-2].strip() if len(parts) >= 2 else None
+
+    return {
+        "slug": slug,
+        "nome": nome,
+        "cidade": cidade or "",
+        "bairro": bairro,
+        "endereco": endereco or "",
+        "telefone": telefone,
+        "horario": horario,
+        "petisco_nome": petisco_nome,
+        "petisco_desc": petisco_desc,
+        "foto_url": foto_url,
+    }
+```
+
+- [ ] **Step 2: Testar com um slug real**
+
+```bash
+cd scraper
+python -c "from main import scrape_buteco; import json; print(json.dumps(scrape_buteco('1-poco-loco'), indent=2, ensure_ascii=False))"
+```
+Esperado: JSON com `nome`, `cidade`, `petisco_nome`, `endereco` preenchidos.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scraper/main.py
+git commit -m "feat(scraper): implementa scrape_buteco"
+```
+
+---
+
+### Task 4: Implementar `upsert_buteco`
+
+**Files:**
+- Modify: `scraper/main.py`
+
+- [ ] **Step 1: Implementar `upsert_buteco`**
+
+Substitua o `pass` em `upsert_buteco`:
+
+```python
+def upsert_buteco(conn, data: dict) -> None:
+    sql = """
+        INSERT INTO "Buteco" (
+            id, slug, nome, cidade, bairro, endereco,
+            telefone, horario, "petiscoNome", "petiscoDesc",
+            "fotoUrl", lat, lng, "createdAt", "updatedAt"
+        ) VALUES (
+            gen_random_uuid()::text, %(slug)s, %(nome)s, %(cidade)s, %(bairro)s, %(endereco)s,
+            %(telefone)s, %(horario)s, %(petisco_nome)s, %(petisco_desc)s,
+            %(foto_url)s, NULL, NULL, NOW(), NOW()
+        )
+        ON CONFLICT (slug) DO UPDATE SET
+            nome          = EXCLUDED.nome,
+            cidade        = EXCLUDED.cidade,
+            bairro        = EXCLUDED.bairro,
+            endereco      = EXCLUDED.endereco,
+            telefone      = EXCLUDED.telefone,
+            horario       = EXCLUDED.horario,
+            "petiscoNome" = EXCLUDED."petiscoNome",
+            "petiscoDesc" = EXCLUDED."petiscoDesc",
+            "fotoUrl"     = EXCLUDED."fotoUrl",
+            "updatedAt"   = NOW()
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, data)
+    conn.commit()
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scraper/main.py
+git commit -m "feat(scraper): implementa upsert_buteco"
+```
+
+---
+
+### Task 5: Implementar `main` e testar end-to-end
+
+**Files:**
+- Modify: `scraper/main.py`
+
+- [ ] **Step 1: Implementar `main`**
+
+Substitua o `pass` em `main`:
+
+```python
+def main() -> None:
+    db_url = os.environ.get("POSTGRES_URL_NON_POOLING")
+    if not db_url:
+        raise RuntimeError("POSTGRES_URL_NON_POOLING não definida")
+
+    conn = psycopg2.connect(db_url)
+    print("Conectado ao banco.")
+
+    page = 1
+    total = 0
+    errors = 0
+
+    while True:
+        print(f"\n[página {page}] buscando slugs...")
+        slugs = get_slugs(page)
+        if not slugs:
+            print(f"  sem resultados — fim da paginação.")
+            break
+
+        for slug in slugs:
+            time.sleep(SLEEP)
+            data = scrape_buteco(slug)
+            if not data:
+                print(f"  {slug} → erro (sem dados)")
+                errors += 1
+                continue
+            try:
+                upsert_buteco(conn, data)
+                print(f"  {slug} → ok")
+                total += 1
+            except Exception as e:
+                print(f"  {slug} → erro no banco: {e}")
+                conn.rollback()
+                errors += 1
+
+        page += 1
+        time.sleep(SLEEP)
+
+    conn.close()
+    print(f"\nConcluído: {total} butecos inseridos/atualizados, {errors} erros.")
+```
+
+- [ ] **Step 2: Criar `.env` local com a URL do banco**
+
+Crie `scraper/.env` (não commitar — já está no `.gitignore` do repo raiz):
+```
+POSTGRES_URL_NON_POOLING=<valor de POSTGRES_URL_NON_POOLING do .env.local do apps/web>
+```
+
+- [ ] **Step 3: Testar com apenas 1 página**
+
+Edite temporariamente `main.py` para parar após page 1 e testar:
+```bash
+cd scraper
+pip install -r requirements.txt
+python -c "
+import os, time, psycopg2
+from dotenv import load_dotenv
+from main import get_slugs, scrape_buteco, upsert_buteco
+load_dotenv()
+conn = psycopg2.connect(os.environ['POSTGRES_URL_NON_POOLING'])
+slugs = get_slugs(1)
+print('slugs:', len(slugs))
+data = scrape_buteco(slugs[0])
+print('data:', data)
+upsert_buteco(conn, data)
+print('upsert ok')
+conn.close()
+"
+```
+Esperado: `upsert ok` sem erros.
+
+- [ ] **Step 4: Rodar scraper completo**
+
+```bash
+cd scraper
+python main.py
+```
+Esperado: progresso impresso por página, terminando com `Concluído: NNN butecos inseridos/atualizados, 0 erros.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scraper/main.py
+git commit -m "feat(scraper): implementa main e fluxo completo"
+```
+
+---
+
+### Task 6: GitHub Actions workflow
+
+**Files:**
+- Create: `.github/workflows/scraper.yml`
+
+- [ ] **Step 1: Criar `.github/workflows/scraper.yml`**
+
+```yaml
+name: Scraper semanal
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Instalar dependências
+        run: pip install -r scraper/requirements.txt
+
+      - name: Rodar scraper
+        env:
+          POSTGRES_URL_NON_POOLING: ${{ secrets.POSTGRES_URL_NON_POOLING }}
+        run: python scraper/main.py
+```
+
+- [ ] **Step 2: Commit e push**
+
+```bash
+git add .github/workflows/scraper.yml
+git commit -m "chore: adiciona GitHub Actions workflow do scraper"
+git push origin main
+```
+
+- [ ] **Step 3: Verificar que o workflow aparece no GitHub**
+
+Acesse `https://github.com/gianimpronta/onde-tem-buteco/actions` e confirme que o workflow `Scraper semanal` aparece. Rode manualmente via "Run workflow" para validar.

--- a/docs/superpowers/plans/2026-04-13-sonarqube-issues.md
+++ b/docs/superpowers/plans/2026-04-13-sonarqube-issues.md
@@ -1,0 +1,298 @@
+# SonarQube Issues Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Corrigir os 4 issues abertos reportados pelo SonarCloud no projeto `gianimpronta_onde-tem-buteco`.
+
+**Architecture:** Dois grupos independentes de mudanças — (1) refatoração do scraper Python para reduzir complexidade cognitiva, (2) três correções de type-safety no app Next.js. Ambos podem ser executados em paralelo por subagentes separados.
+
+**Tech Stack:** Python 3.12 (scraper), TypeScript + Next.js 16 + NextAuth v5 (web)
+
+---
+
+## Contexto dos issues
+
+| # | Arquivo | Linha | Regra | Severidade | Descrição |
+|---|---|---|---|---|---|
+| 1 | `scraper/main.py` | 78 | `python:S3776` | 🟠 Critical | `scrape_buteco` tem complexidade cognitiva 29 (máx 15) |
+| 2 | `apps/web/app/(public)/butecos/[slug]/page.tsx` | 6 | `typescript:S6759` | 🔵 Minor | Props do componente não marcadas como `Readonly` |
+| 3 | `apps/web/app/(public)/butecos/page.tsx` | 3 | `typescript:S6759` | 🔵 Minor | Props do componente não marcadas como `Readonly` |
+| 4 | `apps/web/lib/auth.ts` | 29 | `typescript:S4325` | 🔵 Minor | Type assertion desnecessária na extensão de `session.user` |
+
+---
+
+## Task 1: Reduzir complexidade cognitiva de `scrape_buteco` (S3776)
+
+**Parallelizable:** sim — independente do Task 2.
+
+**Files:**
+- Modify: `scraper/main.py` — extrair duas funções auxiliares de `scrape_buteco`
+
+### Análise do problema
+
+A função `scrape_buteco` tem complexidade 29 por acumular:
+- Loop `for i, p in enumerate(paragraphs)` com `if not bold`, múltiplos `elif`, e lógica de petisco aninhada
+- Bloco `if endereco:` com split/regex/indexing
+
+A solução é extrair duas funções auxiliares:
+- `_parse_section_fields(section)` → `dict` com `endereco`, `telefone`, `horario`, `petisco_nome`, `petisco_desc`
+- `_parse_location(endereco)` → `tuple[str | None, str | None]` com `(cidade, bairro)`
+
+---
+
+- [ ] **Step 1: Ler o arquivo atual**
+
+Confirmar que `scraper/main.py` está no estado esperado (função `scrape_buteco` começa na linha 78).
+
+- [ ] **Step 2: Extrair `_parse_section_fields` e `_parse_location`**
+
+Substituir o conteúdo de `scraper/main.py` adicionando as duas funções antes de `scrape_buteco` e simplificando o corpo da função principal.
+
+O novo conteúdo de `scraper/main.py` a partir da linha 78:
+
+```python
+def _parse_section_fields(section) -> dict:
+    """Extract endereco, telefone, horario and petisco from .section-text."""
+    result = {
+        "endereco": None,
+        "telefone": None,
+        "horario": None,
+        "petisco_nome": None,
+        "petisco_desc": None,
+    }
+    for i, p in enumerate(section.find_all("p")):
+        bold = p.find("b")
+        if not bold:
+            continue
+        label = bold.get_text(strip=True).lower().rstrip(":")
+        bold_text = bold.get_text(strip=True)
+        value = p.get_text(strip=True)[len(bold_text):].strip().lstrip(":").strip()
+
+        if label in ("endereço", "endereco"):
+            result["endereco"] = value
+        elif label == "telefone":
+            result["telefone"] = value
+        elif label in ("horario", "horário"):
+            result["horario"] = value
+        elif i == 0:
+            result["petisco_nome"] = bold_text
+            result["petisco_desc"] = value if value else None
+    return result
+
+
+def _parse_location(endereco: str) -> tuple[str | None, str | None]:
+    """Split endereco string into (cidade, bairro)."""
+    parts = [p.strip() for p in endereco.split(",")]
+    last = parts[-1].strip()
+    if re.match(r"^[A-Z]{2}$", last):
+        parts = parts[:-1]
+    cidade = parts[-1].strip() if parts else None
+    bairro = parts[-2].strip() if len(parts) >= 2 else None
+    return cidade, bairro
+
+
+def scrape_buteco(slug: str) -> dict:
+    url = f"{BASE_URL}/buteco/{slug}/"
+    html = fs_request(url)
+    if not html:
+        return {}
+
+    soup = BeautifulSoup(html, "html.parser")
+    nome_tag = soup.select_one("h1.section-title")
+    if not nome_tag:
+        print(f"  h1.section-title não encontrado em {slug}")
+        return {}
+
+    nome = nome_tag.get_text(strip=True)
+
+    foto_tag = soup.select_one("img.img-single")
+    foto_url = (foto_tag.get("src") or foto_tag.get("data-src")) if foto_tag else None
+
+    section = soup.select_one(".section-text")
+    fields = _parse_section_fields(section) if section else {
+        "endereco": None, "telefone": None, "horario": None,
+        "petisco_nome": None, "petisco_desc": None,
+    }
+
+    endereco = fields["endereco"]
+    cidade, bairro = _parse_location(endereco) if endereco else (None, None)
+
+    return {
+        "slug": slug,
+        "nome": nome,
+        "cidade": cidade or "",
+        "bairro": bairro,
+        "endereco": endereco or "",
+        "telefone": fields["telefone"],
+        "horario": fields["horario"],
+        "petisco_nome": fields["petisco_nome"],
+        "petisco_desc": fields["petisco_desc"],
+        "foto_url": foto_url,
+    }
+```
+
+- [ ] **Step 3: Verificar que ruff passa localmente**
+
+```bash
+cd scraper
+pip install ruff --quiet
+ruff check main.py
+ruff format --check main.py
+```
+
+Expected: nenhum erro.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scraper/main.py
+git commit -m "refactor: extrai _parse_section_fields e _parse_location (S3776)"
+```
+
+---
+
+## Task 2: Corrigir issues TypeScript (S6759 × 2 + S4325)
+
+**Parallelizable:** sim — independente do Task 1.
+
+**Files:**
+- Modify: `apps/web/app/(public)/butecos/[slug]/page.tsx:6`
+- Modify: `apps/web/app/(public)/butecos/page.tsx:3`
+- Create: `apps/web/types/next-auth.d.ts`
+- Modify: `apps/web/lib/auth.ts:29`
+
+---
+
+### Sub-task 2a: Marcar props como `Readonly` (S6759)
+
+- [ ] **Step 1: Corrigir `[slug]/page.tsx`**
+
+Em `apps/web/app/(public)/butecos/[slug]/page.tsx`, linha 6, alterar:
+
+```typescript
+// antes
+export default async function ButecoPage({ params }: { params: Promise<{ slug: string }> }) {
+
+// depois
+export default async function ButecoPage({ params }: Readonly<{ params: Promise<{ slug: string }> }>) {
+```
+
+- [ ] **Step 2: Corrigir `butecos/page.tsx`**
+
+Em `apps/web/app/(public)/butecos/page.tsx`, linhas 3–7, alterar:
+
+```typescript
+// antes
+export default async function ButecosPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ cidade?: string; bairro?: string; q?: string }>;
+}) {
+
+// depois
+export default async function ButecosPage({
+  searchParams,
+}: Readonly<{ searchParams: Promise<{ cidade?: string; bairro?: string; q?: string }> }>) {
+```
+
+---
+
+### Sub-task 2b: Remover type assertion desnecessária em `auth.ts` (S4325)
+
+O problema: `(session.user as typeof session.user & { id: string }).id = dbUser.id` faz um cast inline que SonarQube aponta como desnecessário. A solução correta para NextAuth v5 é fazer module augmentation do tipo `Session`.
+
+- [ ] **Step 3: Criar `apps/web/types/next-auth.d.ts`**
+
+```typescript
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+    } & DefaultSession["user"];
+  }
+}
+```
+
+- [ ] **Step 4: Atualizar `apps/web/lib/auth.ts`**
+
+Linha 29: substituir o cast inline por atribuição direta:
+
+```typescript
+// antes
+(session.user as typeof session.user & { id: string }).id = dbUser.id;
+
+// depois
+session.user.id = dbUser.id;
+```
+
+O arquivo completo após a mudança:
+
+```typescript
+import NextAuth from "next-auth";
+import Google from "next-auth/providers/google";
+import { prisma } from "./prisma";
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+  ],
+  callbacks: {
+    async signIn({ user }) {
+      if (!user.email) return false;
+      await prisma.user.upsert({
+        where: { email: user.email },
+        update: { name: user.name, image: user.image },
+        create: { email: user.email, name: user.name, image: user.image },
+      });
+      return true;
+    },
+    async session({ session }) {
+      if (session.user?.email) {
+        const dbUser = await prisma.user.findUnique({
+          where: { email: session.user.email },
+          select: { id: true },
+        });
+        if (dbUser) {
+          session.user.id = dbUser.id;
+        }
+      }
+      return session;
+    },
+  },
+});
+```
+
+- [ ] **Step 5: Verificar type check**
+
+```bash
+cd apps/web
+npx tsc --noEmit
+```
+
+Expected: sem erros de tipo.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/app/\(public\)/butecos/\[slug\]/page.tsx
+git add apps/web/app/\(public\)/butecos/page.tsx
+git add apps/web/types/next-auth.d.ts
+git add apps/web/lib/auth.ts
+git commit -m "fix: marca props como Readonly e remove type assertion desnecessária (S6759, S4325)"
+```
+
+---
+
+## Verificação final
+
+Após ambas as tasks (em qualquer ordem):
+
+- [ ] Push para main: `git push origin main`
+- [ ] Aguardar execução das pipelines CI no GitHub Actions
+- [ ] Confirmar que quality e security workflows passam
+- [ ] Verificar no SonarCloud que os 4 issues aparecem como FIXED

--- a/docs/superpowers/plans/2026-04-14-testes-python.md
+++ b/docs/superpowers/plans/2026-04-14-testes-python.md
@@ -1,0 +1,520 @@
+# Python Unit Tests — scraper/main.py Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Write unit tests for `scraper/main.py` to bring Python coverage above the SonarCloud 80% threshold.
+
+**Architecture:** Pure functions (`_parse_location`, `_parse_section_fields`) are tested directly with fixtures. Network-dependent functions (`get_slugs`, `scrape_buteco`) are tested with `unittest.mock.patch` targeting `scraper.main.fs_request`. All tests live in `scraper/tests/test_main.py` and are discovered by pytest.
+
+**Tech Stack:** pytest 8.3.5, pytest-cov 6.1.0, beautifulsoup4 4.12.3, unittest.mock (stdlib)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `scraper/tests/test_main.py` | Create | All unit tests |
+| `scraper/tests/__init__.py` | Already exists | Package marker |
+| `scraper/.coveragerc` | Already exists | Omits test files from coverage |
+| `scraper/requirements.txt` | Modify | Add pytest + pytest-cov dev deps |
+
+---
+
+### Task 1: Tests for `_parse_location`
+
+`_parse_location(endereco)` splits an address string into `(cidade, bairro)`. It strips trailing UF codes (e.g., `SP`, `MG`) and takes the last and second-to-last comma-separated parts.
+
+**Files:**
+- Create: `scraper/tests/test_main.py`
+
+- [ ] **Step 1: Add pytest and pytest-cov to requirements.txt**
+
+Open `scraper/requirements.txt` and append:
+
+```
+pytest==8.3.5
+pytest-cov==6.1.0
+```
+
+- [ ] **Step 2: Write failing tests for `_parse_location`**
+
+Create `scraper/tests/test_main.py`:
+
+```python
+import pytest
+from scraper.main import _parse_location
+
+
+class TestParseLocation:
+    def test_full_address_with_uf(self):
+        endereco = "Rua das Flores, 123, Centro, Belo Horizonte, MG"
+        cidade, bairro = _parse_location(endereco)
+        assert cidade == "Belo Horizonte"
+        assert bairro == "Centro"
+
+    def test_full_address_without_uf(self):
+        endereco = "Rua das Flores, 123, Centro, Belo Horizonte"
+        cidade, bairro = _parse_location(endereco)
+        assert cidade == "Belo Horizonte"
+        assert bairro == "Centro"
+
+    def test_address_only_city(self):
+        # Only one part after stripping UF → bairro is None
+        endereco = "Belo Horizonte, MG"
+        cidade, bairro = _parse_location(endereco)
+        assert cidade == "Belo Horizonte"
+        assert bairro is None
+
+    def test_address_city_and_bairro_no_uf(self):
+        endereco = "Santa Efigênia, Belo Horizonte"
+        cidade, bairro = _parse_location(endereco)
+        assert cidade == "Belo Horizonte"
+        assert bairro == "Santa Efigênia"
+
+    def test_address_trims_whitespace(self):
+        endereco = "  Rua X ,  Centro ,  Curitiba , PR  "
+        cidade, bairro = _parse_location(endereco)
+        assert cidade == "Curitiba"
+        assert bairro == "Centro"
+
+    def test_single_part_no_uf(self):
+        endereco = "Belo Horizonte"
+        cidade, bairro = _parse_location(endereco)
+        assert cidade == "Belo Horizonte"
+        assert bairro is None
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd E:/repo/onde-tem-buteco
+python -m pytest scraper/tests/test_main.py::TestParseLocation -v
+```
+
+Expected: `ImportError` or `ModuleNotFoundError` — `scraper.main` not importable yet (no `scraper/__init__.py`).
+
+- [ ] **Step 4: Create `scraper/__init__.py` to make it a package**
+
+```bash
+touch scraper/__init__.py
+```
+
+Or create the file with empty content.
+
+- [ ] **Step 5: Run tests again**
+
+```bash
+cd E:/repo/onde-tem-buteco
+python -m pytest scraper/tests/test_main.py::TestParseLocation -v
+```
+
+Expected: All 6 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scraper/__init__.py scraper/tests/test_main.py scraper/requirements.txt
+git commit -m "test: adiciona testes unitários para _parse_location"
+```
+
+---
+
+### Task 2: Tests for `_parse_section_fields`
+
+`_parse_section_fields(section)` takes a BeautifulSoup element (`.section-text`) and returns a dict with `endereco`, `telefone`, `horario`, `petisco_nome`, `petisco_desc`. The first `<p>` with a `<b>` that doesn't match known labels becomes the petisco.
+
+**Files:**
+- Modify: `scraper/tests/test_main.py`
+
+- [ ] **Step 1: Write failing tests for `_parse_section_fields`**
+
+Append to `scraper/tests/test_main.py`:
+
+```python
+from bs4 import BeautifulSoup
+from scraper.main import _parse_section_fields
+
+
+def _make_section(html: str) -> BeautifulSoup:
+    """Wrap html in a div and return the div element."""
+    soup = BeautifulSoup(f"<div class='section-text'>{html}</div>", "html.parser")
+    return soup.select_one(".section-text")
+
+
+class TestParseSectionFields:
+    def test_all_fields_present(self):
+        section = _make_section("""
+            <p><b>Petisco Incrível</b> Descrição do petisco</p>
+            <p><b>Endereço:</b> Rua X, 10, Centro, BH, MG</p>
+            <p><b>Telefone:</b> (31) 9999-9999</p>
+            <p><b>Horário:</b> Seg a Sex 18h–23h</p>
+        """)
+        result = _parse_section_fields(section)
+        assert result["petisco_nome"] == "Petisco Incrível"
+        assert result["petisco_desc"] == "Descrição do petisco"
+        assert result["endereco"] == "Rua X, 10, Centro, BH, MG"
+        assert result["telefone"] == "(31) 9999-9999"
+        assert result["horario"] == "Seg a Sex 18h–23h"
+
+    def test_endereco_accent_variant(self):
+        section = _make_section("""
+            <p><b>Endereço:</b> Av. Brasil, 1, São Paulo</p>
+        """)
+        result = _parse_section_fields(section)
+        assert result["endereco"] == "Av. Brasil, 1, São Paulo"
+
+    def test_endereco_no_accent(self):
+        section = _make_section("""
+            <p><b>Endereco:</b> Av. Brasil, 1, São Paulo</p>
+        """)
+        result = _parse_section_fields(section)
+        assert result["endereco"] == "Av. Brasil, 1, São Paulo"
+
+    def test_missing_optional_fields_return_none(self):
+        section = _make_section("""
+            <p><b>Endereço:</b> Rua Y, 5, Centro, BH</p>
+        """)
+        result = _parse_section_fields(section)
+        assert result["telefone"] is None
+        assert result["horario"] is None
+        assert result["petisco_nome"] is None
+        assert result["petisco_desc"] is None
+
+    def test_petisco_without_description(self):
+        section = _make_section("""
+            <p><b>Só o Nome</b></p>
+        """)
+        result = _parse_section_fields(section)
+        assert result["petisco_nome"] == "Só o Nome"
+        assert result["petisco_desc"] is None
+
+    def test_paragraph_without_bold_is_ignored(self):
+        section = _make_section("""
+            <p>Texto sem negrito</p>
+            <p><b>Endereço:</b> Rua Z</p>
+        """)
+        result = _parse_section_fields(section)
+        assert result["endereco"] == "Rua Z"
+
+    def test_empty_section_returns_all_none(self):
+        section = _make_section("")
+        result = _parse_section_fields(section)
+        assert result == {
+            "endereco": None,
+            "telefone": None,
+            "horario": None,
+            "petisco_nome": None,
+            "petisco_desc": None,
+        }
+
+    def test_horario_accent_variant(self):
+        section = _make_section("""
+            <p><b>Horario:</b> Dom 12h–18h</p>
+        """)
+        result = _parse_section_fields(section)
+        assert result["horario"] == "Dom 12h–18h"
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+cd E:/repo/onde-tem-buteco
+python -m pytest scraper/tests/test_main.py::TestParseSectionFields -v
+```
+
+Expected: All 8 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scraper/tests/test_main.py
+git commit -m "test: adiciona testes unitários para _parse_section_fields"
+```
+
+---
+
+### Task 3: Tests for `get_slugs`
+
+`get_slugs(page)` calls `fs_request(url)`, parses the HTML and extracts unique slugs from `a[href*='/buteco/']` links. Returns `[]` on empty HTML or no matches.
+
+**Files:**
+- Modify: `scraper/tests/test_main.py`
+
+- [ ] **Step 1: Write failing tests for `get_slugs`**
+
+Append to `scraper/tests/test_main.py`:
+
+```python
+from unittest.mock import patch
+from scraper.main import get_slugs
+
+
+class TestGetSlugs:
+    def test_returns_slugs_from_html(self):
+        html = """
+        <html><body>
+          <a href="/buteco/bar-do-ze/">Bar do Zé</a>
+          <a href="/buteco/boteco-antigo/">Boteco Antigo</a>
+        </body></html>
+        """
+        with patch("scraper.main.fs_request", return_value=html) as mock_fs:
+            result = get_slugs(1)
+        mock_fs.assert_called_once_with("https://comidadibuteco.com.br/butecos/page/1/")
+        assert result == ["bar-do-ze", "boteco-antigo"]
+
+    def test_deduplicates_slugs(self):
+        html = """
+        <html><body>
+          <a href="/buteco/bar-do-ze/">Link 1</a>
+          <a href="/buteco/bar-do-ze/">Link 2 duplicado</a>
+          <a href="/buteco/boteco-antigo/">Boteco Antigo</a>
+        </body></html>
+        """
+        with patch("scraper.main.fs_request", return_value=html):
+            result = get_slugs(1)
+        assert result == ["bar-do-ze", "boteco-antigo"]
+        assert len(result) == 2
+
+    def test_returns_empty_on_empty_html(self):
+        with patch("scraper.main.fs_request", return_value=""):
+            result = get_slugs(1)
+        assert result == []
+
+    def test_returns_empty_when_no_buteco_links(self):
+        html = "<html><body><a href='/outra/pagina/'>Outro</a></body></html>"
+        with patch("scraper.main.fs_request", return_value=html):
+            result = get_slugs(1)
+        assert result == []
+
+    def test_uses_correct_page_url(self):
+        html = "<html><body><a href='/buteco/slug-x/'>X</a></body></html>"
+        with patch("scraper.main.fs_request", return_value=html) as mock_fs:
+            get_slugs(5)
+        mock_fs.assert_called_once_with("https://comidadibuteco.com.br/butecos/page/5/")
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+cd E:/repo/onde-tem-buteco
+python -m pytest scraper/tests/test_main.py::TestGetSlugs -v
+```
+
+Expected: All 5 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scraper/tests/test_main.py
+git commit -m "test: adiciona testes unitários para get_slugs"
+```
+
+---
+
+### Task 4: Tests for `scrape_buteco`
+
+`scrape_buteco(slug)` calls `fs_request(url)`, parses the full buteco page HTML, and returns a dict with all fields. Returns `{}` on empty HTML or missing `h1.section-title`.
+
+**Files:**
+- Modify: `scraper/tests/test_main.py`
+
+- [ ] **Step 1: Write failing tests for `scrape_buteco`**
+
+Append to `scraper/tests/test_main.py`:
+
+```python
+from scraper.main import scrape_buteco
+
+
+def _buteco_html(
+    nome="Bar do Zé",
+    foto_src=None,
+    foto_data_src=None,
+    endereco="Rua X, 10, Centro, Belo Horizonte, MG",
+    telefone="(31) 9999-9999",
+    horario="Seg–Sex 18h–23h",
+    petisco_nome="Bolinho de Bacalhau",
+    petisco_desc="Crocante por fora",
+) -> str:
+    foto_attrs = ""
+    if foto_src:
+        foto_attrs = f'src="{foto_src}"'
+    elif foto_data_src:
+        foto_attrs = f'data-src="{foto_data_src}"'
+
+    foto_tag = f'<img class="img-single" {foto_attrs} />' if (foto_src or foto_data_src) else ""
+
+    return f"""
+    <html><body>
+      <h1 class="section-title">{nome}</h1>
+      {foto_tag}
+      <div class="section-text">
+        <p><b>{petisco_nome}</b> {petisco_desc}</p>
+        <p><b>Endereço:</b> {endereco}</p>
+        <p><b>Telefone:</b> {telefone}</p>
+        <p><b>Horário:</b> {horario}</p>
+      </div>
+    </body></html>
+    """
+
+
+class TestScrapButeco:
+    def test_returns_full_data(self):
+        html = _buteco_html()
+        with patch("scraper.main.fs_request", return_value=html) as mock_fs:
+            result = scrape_buteco("bar-do-ze")
+        mock_fs.assert_called_once_with("https://comidadibuteco.com.br/buteco/bar-do-ze/")
+        assert result["slug"] == "bar-do-ze"
+        assert result["nome"] == "Bar do Zé"
+        assert result["cidade"] == "Belo Horizonte"
+        assert result["bairro"] == "Centro"
+        assert result["endereco"] == "Rua X, 10, Centro, Belo Horizonte, MG"
+        assert result["telefone"] == "(31) 9999-9999"
+        assert result["horario"] == "Seg–Sex 18h–23h"
+        assert result["petisco_nome"] == "Bolinho de Bacalhau"
+        assert result["petisco_desc"] == "Crocante por fora"
+
+    def test_foto_url_from_src(self):
+        html = _buteco_html(foto_src="https://cdn.example.com/foto.jpg")
+        with patch("scraper.main.fs_request", return_value=html):
+            result = scrape_buteco("bar-do-ze")
+        assert result["foto_url"] == "https://cdn.example.com/foto.jpg"
+
+    def test_foto_url_from_data_src(self):
+        html = _buteco_html(foto_data_src="https://cdn.example.com/lazy.jpg")
+        with patch("scraper.main.fs_request", return_value=html):
+            result = scrape_buteco("bar-do-ze")
+        assert result["foto_url"] == "https://cdn.example.com/lazy.jpg"
+
+    def test_no_foto_returns_none(self):
+        html = _buteco_html()
+        with patch("scraper.main.fs_request", return_value=html):
+            result = scrape_buteco("bar-do-ze")
+        assert result["foto_url"] is None
+
+    def test_returns_empty_dict_on_empty_html(self):
+        with patch("scraper.main.fs_request", return_value=""):
+            result = scrape_buteco("nao-existe")
+        assert result == {}
+
+    def test_returns_empty_dict_when_no_h1(self):
+        html = "<html><body><p>Sem título</p></body></html>"
+        with patch("scraper.main.fs_request", return_value=html):
+            result = scrape_buteco("sem-titulo")
+        assert result == {}
+
+    def test_no_section_text_returns_none_fields(self):
+        html = """
+        <html><body>
+          <h1 class="section-title">Bar Vazio</h1>
+        </body></html>
+        """
+        with patch("scraper.main.fs_request", return_value=html):
+            result = scrape_buteco("bar-vazio")
+        assert result["nome"] == "Bar Vazio"
+        assert result["endereco"] == ""
+        assert result["cidade"] == ""
+        assert result["bairro"] is None
+        assert result["telefone"] is None
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+cd E:/repo/onde-tem-buteco
+python -m pytest scraper/tests/test_main.py::TestScrapButeco -v
+```
+
+Expected: All 8 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scraper/tests/test_main.py
+git commit -m "test: adiciona testes unitários para scrape_buteco"
+```
+
+---
+
+### Task 5: Verify coverage report
+
+Run the full test suite with coverage and confirm the XML report is generated and meets the 80% threshold.
+
+**Files:**
+- No changes — verify existing config works end-to-end.
+
+- [ ] **Step 1: Install test dependencies**
+
+```bash
+cd E:/repo/onde-tem-buteco/scraper
+pip install pytest==8.3.5 pytest-cov==6.1.0 beautifulsoup4==4.12.3
+```
+
+- [ ] **Step 2: Run all tests with coverage**
+
+```bash
+cd E:/repo/onde-tem-buteco
+python -m pytest scraper/tests/ \
+  --cov=scraper \
+  --cov-report=xml:scraper/coverage.xml \
+  --cov-report=term-missing \
+  --cov-config=scraper/.coveragerc \
+  -v
+```
+
+Expected output:
+- All tests PASS (no failures)
+- Coverage report shows `scraper/main.py` coverage ≥ 80%
+- `scraper/coverage.xml` is created
+
+- [ ] **Step 3: Verify coverage.xml exists**
+
+```bash
+head -5 scraper/coverage.xml
+```
+
+Expected: XML header + `<coverage>` root element.
+
+- [ ] **Step 4: Verify `scraper/__init__.py` is not accidentally covered**
+
+Check the coverage term output — `scraper/__init__.py` should appear with 100% (empty file) and `scraper/tests/test_main.py` should NOT appear (omitted by `.coveragerc`).
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add scraper/__init__.py scraper/tests/test_main.py scraper/requirements.txt
+git push
+```
+
+Note: If `scraper/__init__.py` was already committed in Task 1, only add the remaining files.
+
+- [ ] **Step 6: Verify CI passes**
+
+After pushing, check the `coverage-python` job in GitHub Actions:
+
+```
+https://github.com/gianimpronta/onde-tem-buteco/actions
+```
+
+Expected: `coverage-python` job succeeds, uploads `scraper/coverage.xml` artifact.
+
+---
+
+## Self-Review
+
+### Spec Coverage
+- `_parse_location` → Task 1 ✅
+- `_parse_section_fields` → Task 2 ✅
+- `get_slugs` → Task 3 ✅
+- `scrape_buteco` → Task 4 ✅
+- CI coverage report → Task 5 ✅
+- SonarCloud 80% threshold → Covered by Task 5 verification
+
+### Functions NOT covered by tests (intentional)
+- `fs_request` — thin wrapper over `requests.post`; tested implicitly via mocks
+- `fs_create_session` — same; fire-and-forget, ignores exceptions
+- `upsert_buteco` — requires a live database connection; excluded from unit test scope
+- `main` — orchestration; requires live DB + FlareSolverr
+
+Coverage of the 4 targeted functions should bring `scraper/main.py` to ~65–75% line coverage. If SonarCloud still fails the 80% gate, add tests for `fs_request` (mock `requests.post`) and `fs_create_session` as a bonus Task 6.


### PR DESCRIPTION
## Summary
- Add search and filters to the butecos list, with query-string sync and updated empty states
- Extract reusable filter logic and cover it with unit tests
- Fix homepage build/runtime issues by moving the Leaflet map wrapper to a client component
- Harden Prisma connection handling for Vercel/Postgres TLS and direct pool access

Refs #30

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint "app/(public)/page.tsx" "components/mapa/mapa-butecos-shell.tsx" "lib/prisma.ts"`
- `pnpm test -- --runInBand`
- `pnpm exec next build`
