### PR TITLE
Fix and backfill geolocation for butecos

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ pip install -r requirements.txt
 DATABASE_URL=<url> python main.py
 ```
 
+Para reprocessar apenas os butecos que já estão no banco sem `lat/lng`:
+
+```bash
+cd scraper
+pip install -r requirements.txt
+DATABASE_URL=<url> python main.py --skip-scrape --backfill-missing-geocodes
+```
+
 ---
 
 ## Variáveis de ambiente necessárias

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -137,11 +137,10 @@ def _normalize_address(endereco: str) -> str:
     normalized = _normalize_whitespace(endereco)
     normalized = normalized.replace("|", ", ")
     normalized = re.sub(r"\bCEP[:\s-]*\d{5}-?\d{3}\b", "", normalized, flags=re.IGNORECASE)
-    normalized = re.sub(r"\s+[–-]\s+([A-Z]{2})$", r", \1", normalized)
-    normalized = re.sub(r"\s*-\s*", ", ", normalized)
-    normalized = re.sub(r"\s*,\s*", ", ", normalized)
-    normalized = re.sub(r"(,\s*){2,}", ", ", normalized)
-    return normalized.strip(" ,")
+    normalized = normalized.replace(" – ", ", ")
+    normalized = normalized.replace(" - ", ", ")
+    parts = [part.strip() for part in normalized.split(",") if part.strip()]
+    return ", ".join(parts)
 
 
 def _build_geocode_queries(

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -1,8 +1,10 @@
+import argparse
 import os
 import re
 import sys
 import time
 import unicodedata
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import psycopg2
 import requests
@@ -14,6 +16,7 @@ load_dotenv()
 BASE_URL = "https://comidadibuteco.com.br"
 FLARESOLVERR = "http://localhost:8191/v1"
 SLEEP = 0.5
+GEOCODE_SLEEP = 1.0
 SESSION_ID = "scraper-session"
 NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 USER_AGENT = "onde-tem-buteco-scraper/1.0"
@@ -109,7 +112,8 @@ def _parse_section_fields(section) -> dict:
 
 def _parse_location(endereco: str) -> tuple[str | None, str | None]:
     """Split endereco string into (cidade, bairro)."""
-    parts = [p.strip() for p in endereco.split(",")]
+    normalized = _normalize_address(endereco)
+    parts = [p.strip() for p in normalized.split(",") if p.strip()]
     last = parts[-1].strip()
     if re.match(r"^[A-Z]{2}$", last):
         parts = parts[:-1]
@@ -125,21 +129,283 @@ def _slugify(name: str) -> str:
     return slug
 
 
-def geocode_address(endereco: str) -> tuple[float | None, float | None]:
-    try:
-        resp = requests.get(
-            NOMINATIM_URL,
-            params={"q": endereco, "format": "json", "limit": 1},
-            headers={"User-Agent": USER_AGENT},
-            timeout=20,
-        )
-        data = resp.json()
+def _normalize_whitespace(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _normalize_address(endereco: str) -> str:
+    normalized = _normalize_whitespace(endereco)
+    normalized = normalized.replace("|", ", ")
+    normalized = re.sub(r"\bCEP[:\s-]*\d{5}-?\d{3}\b", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\s+[–-]\s+([A-Z]{2})$", r", \1", normalized)
+    normalized = re.sub(r"\s*-\s*", ", ", normalized)
+    normalized = re.sub(r"\s*,\s*", ", ", normalized)
+    normalized = re.sub(r"(,\s*){2,}", ", ", normalized)
+    return normalized.strip(" ,")
+
+
+def _build_geocode_queries(
+    endereco: str,
+    cidade: str | None = None,
+    bairro: str | None = None,
+) -> list[str]:
+    normalized_address = _normalize_address(endereco)
+    normalized_city = _normalize_whitespace(cidade) if cidade else ""
+    normalized_district = _normalize_whitespace(bairro) if bairro else ""
+    address_parts = [part.strip() for part in normalized_address.split(",") if part.strip()]
+
+    queries: list[str] = []
+    seen: set[str] = set()
+
+    def add_query(value: str) -> None:
+        query = _normalize_address(value)
+        if query and query not in seen:
+            seen.add(query)
+            queries.append(query)
+
+    add_query(normalized_address)
+
+    if normalized_city:
+        add_query(f"{normalized_address}, {normalized_city}, Brasil")
+
+    if len(address_parts) >= 2:
+        add_query(", ".join(address_parts[-2:]))
+
+    if normalized_district and normalized_city:
+        add_query(f"{normalized_district}, {normalized_city}, Brasil")
+
+    if normalized_city:
+        add_query(f"{normalized_city}, Brasil")
+
+    return queries
+
+
+def _sanitize_database_url(url: str) -> str:
+    parts = urlsplit(url)
+    filtered_query = [(key, value) for key, value in parse_qsl(parts.query, keep_blank_values=True) if key != "pgbouncer"]
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(filtered_query), parts.fragment))
+
+
+def resolve_database_url() -> str:
+    for env_name in ("POSTGRES_URL_NON_POOLING", "DATABASE_URL", "POSTGRES_PRISMA_URL"):
+        raw_url = os.environ.get(env_name)
+        if raw_url:
+            return _sanitize_database_url(raw_url)
+
+    raise RuntimeError(
+        "Configure POSTGRES_URL_NON_POOLING, DATABASE_URL ou POSTGRES_PRISMA_URL antes de rodar o scraper"
+    )
+
+
+def geocode_address(
+    endereco: str,
+    cidade: str | None = None,
+    bairro: str | None = None,
+    *,
+    sleep_seconds: float = GEOCODE_SLEEP,
+) -> tuple[float | None, float | None]:
+    queries = _build_geocode_queries(endereco, cidade, bairro)
+
+    for index, query in enumerate(queries):
+        if index > 0 and sleep_seconds > 0:
+            time.sleep(sleep_seconds)
+
+        try:
+            resp = requests.get(
+                NOMINATIM_URL,
+                params={
+                    "q": query,
+                    "format": "jsonv2",
+                    "limit": 1,
+                    "countrycodes": "br",
+                    "addressdetails": 0,
+                },
+                headers={"User-Agent": USER_AGENT, "Accept-Language": "pt-BR"},
+                timeout=20,
+            )
+            data = resp.json()
+        except Exception as exc:
+            print(f"  geocode falhou para '{query}': {exc}")
+            continue
+
         if not data:
-            return None, None
+            continue
+
         first = data[0]
         return float(first["lat"]), float(first["lon"])
-    except Exception:
-        return None, None
+
+    return None, None
+
+
+def fetch_butecos_missing_coordinates(conn) -> list[dict[str, str | None]]:
+    sql = """
+        SELECT slug, endereco, cidade, bairro
+        FROM "Buteco"
+        WHERE (lat IS NULL OR lng IS NULL)
+          AND COALESCE(endereco, '') <> ''
+        ORDER BY nome ASC
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        rows = cur.fetchall()
+
+    return [
+        {
+            "slug": slug,
+            "endereco": endereco,
+            "cidade": cidade,
+            "bairro": bairro,
+        }
+        for slug, endereco, cidade, bairro in rows
+    ]
+
+
+def update_buteco_coordinates(conn, slug: str, lat: float, lng: float) -> bool:
+    sql = """
+        UPDATE "Buteco"
+        SET lat = %s,
+            lng = %s,
+            "updatedAt" = NOW()
+        WHERE slug = %s
+          AND (lat IS NULL OR lng IS NULL)
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (lat, lng, slug))
+        updated = cur.rowcount > 0
+    conn.commit()
+    return updated
+
+
+def backfill_missing_coordinates(conn) -> tuple[int, int]:
+    pending = fetch_butecos_missing_coordinates(conn)
+    if not pending:
+        print("\n[backfill] nenhum buteco pendente de geolocalização.")
+        return 0, 0
+
+    print(f"\n[backfill] reprocessando {len(pending)} butecos sem coordenadas...")
+
+    updated = 0
+    failed = 0
+
+    for item in pending:
+        lat, lng = geocode_address(
+            item["endereco"] or "",
+            cidade=item["cidade"],
+            bairro=item["bairro"],
+        )
+        if lat is None or lng is None:
+            print(f"  {item['slug']} → sem coordenadas")
+            failed += 1
+            continue
+
+        if update_buteco_coordinates(conn, item["slug"] or "", lat, lng):
+            print(f"  {item['slug']} → coordenadas atualizadas")
+            updated += 1
+
+    return updated, failed
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Scraper do Onde Tem Buteco")
+    parser.add_argument(
+        "--skip-scrape",
+        action="store_true",
+        help="pula a etapa de scraping e roda apenas o backfill, se habilitado",
+    )
+    parser.add_argument(
+        "--backfill-missing-geocodes",
+        action="store_true",
+        help="reprocessa butecos já salvos com lat/lng nulos usando o endereço do banco",
+    )
+    return parser.parse_args(argv if argv is not None else [])
+
+
+def scrape_and_upsert_butecos(conn) -> tuple[int, int]:
+    fs_create_session()
+    print("Sessão FlareSolverr criada.")
+
+    page_num = 1
+    total = 0
+    errors = 0
+
+    while True:
+        print(f"\n[página {page_num}] buscando slugs...")
+        slugs = get_slugs(page_num)
+        if not slugs:
+            print("  sem resultados — fim da paginação.")
+            break
+
+        for slug in slugs:
+            time.sleep(SLEEP)
+            data = scrape_buteco(slug)
+            if not data:
+                print(f"  {slug} → erro (sem dados)")
+                errors += 1
+                continue
+            try:
+                upsert_buteco(conn, data)
+                print(f"  {slug} → ok")
+                total += 1
+            except Exception as e:
+                print(f"  {slug} → erro no banco: {e}")
+                conn.rollback()
+                errors += 1
+
+        page_num += 1
+        time.sleep(SLEEP)
+
+    return total, errors
+
+
+def should_exit_with_error(
+    total: int,
+    errors: int,
+    backfill_attempted: bool,
+    backfill_updated: int,
+    backfill_failed: int,
+) -> bool:
+    if total > 0 or errors == 0:
+        return False
+
+    if not backfill_attempted:
+        return True
+
+    return backfill_updated == 0 and backfill_failed > 0
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    db_url = resolve_database_url()
+    conn = psycopg2.connect(db_url)
+    print("Conectado ao banco.")
+
+    total = 0
+    errors = 0
+    backfill_updated = 0
+    backfill_failed = 0
+
+    if not args.skip_scrape:
+        total, errors = scrape_and_upsert_butecos(conn)
+
+    if args.backfill_missing_geocodes:
+        backfill_updated, backfill_failed = backfill_missing_coordinates(conn)
+
+    conn.close()
+    print(f"\nConcluído: {total} butecos inseridos/atualizados, {errors} erros.")
+
+    if args.backfill_missing_geocodes:
+        print(
+            f"Backfill: {backfill_updated} butecos geolocalizados, {backfill_failed} ainda pendentes."
+        )
+
+    if should_exit_with_error(
+        total,
+        errors,
+        args.backfill_missing_geocodes,
+        backfill_updated,
+        backfill_failed,
+    ):
+        sys.exit(1)
 
 
 def scrape_buteco(slug: str) -> dict:
@@ -175,7 +441,7 @@ def scrape_buteco(slug: str) -> dict:
     endereco = fields["endereco"]
     cidade, bairro = _parse_location(endereco) if endereco else (None, None)
 
-    lat, lng = geocode_address(endereco) if endereco else (None, None)
+    lat, lng = geocode_address(endereco, cidade=cidade, bairro=bairro) if endereco else (None, None)
     final_slug = slug or _slugify(nome)
 
     return {
@@ -215,8 +481,8 @@ def upsert_buteco(conn, data: dict) -> None:
             "petiscoNome" = EXCLUDED."petiscoNome",
             "petiscoDesc" = EXCLUDED."petiscoDesc",
             "fotoUrl"     = EXCLUDED."fotoUrl",
-            lat           = EXCLUDED.lat,
-            lng           = EXCLUDED.lng,
+            lat           = COALESCE(EXCLUDED.lat, "Buteco".lat),
+            lng           = COALESCE(EXCLUDED.lng, "Buteco".lng),
             "updatedAt"   = NOW()
     """
     with conn.cursor() as cur:
@@ -224,53 +490,5 @@ def upsert_buteco(conn, data: dict) -> None:
     conn.commit()
 
 
-def main() -> None:
-    db_url = os.environ.get("POSTGRES_URL_NON_POOLING")
-    if not db_url:
-        raise RuntimeError("POSTGRES_URL_NON_POOLING não definida")
-
-    conn = psycopg2.connect(db_url)
-    print("Conectado ao banco.")
-
-    fs_create_session()
-    print("Sessão FlareSolverr criada.")
-
-    page_num = 1
-    total = 0
-    errors = 0
-
-    while True:
-        print(f"\n[página {page_num}] buscando slugs...")
-        slugs = get_slugs(page_num)
-        if not slugs:
-            print("  sem resultados — fim da paginação.")
-            break
-
-        for slug in slugs:
-            time.sleep(SLEEP)
-            data = scrape_buteco(slug)
-            if not data:
-                print(f"  {slug} → erro (sem dados)")
-                errors += 1
-                continue
-            try:
-                upsert_buteco(conn, data)
-                print(f"  {slug} → ok")
-                total += 1
-            except Exception as e:
-                print(f"  {slug} → erro no banco: {e}")
-                conn.rollback()
-                errors += 1
-
-        page_num += 1
-        time.sleep(SLEEP)
-
-    conn.close()
-    print(f"\nConcluído: {total} butecos inseridos/atualizados, {errors} erros.")
-
-    if total == 0 and errors > 0:
-        sys.exit(1)
-
-
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -182,8 +182,14 @@ def _build_geocode_queries(
 
 def _sanitize_database_url(url: str) -> str:
     parts = urlsplit(url)
-    filtered_query = [(key, value) for key, value in parse_qsl(parts.query, keep_blank_values=True) if key != "pgbouncer"]
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(filtered_query), parts.fragment))
+    filtered_query = [
+        (key, value)
+        for key, value in parse_qsl(parts.query, keep_blank_values=True)
+        if key != "pgbouncer"
+    ]
+    return urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, urlencode(filtered_query), parts.fragment)
+    )
 
 
 def resolve_database_url() -> str:
@@ -193,7 +199,8 @@ def resolve_database_url() -> str:
             return _sanitize_database_url(raw_url)
 
     raise RuntimeError(
-        "Configure POSTGRES_URL_NON_POOLING, DATABASE_URL ou POSTGRES_PRISMA_URL antes de rodar o scraper"
+        "Configure POSTGRES_URL_NON_POOLING, DATABASE_URL "
+        "ou POSTGRES_PRISMA_URL antes de rodar o scraper"
     )
 
 
@@ -395,7 +402,9 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.backfill_missing_geocodes:
         print(
-            f"Backfill: {backfill_updated} butecos geolocalizados, {backfill_failed} ainda pendentes."
+            "Backfill: "
+            f"{backfill_updated} butecos geolocalizados, "
+            f"{backfill_failed} ainda pendentes."
         )
 
     if should_exit_with_error(

--- a/scraper/tests/test_main.py
+++ b/scraper/tests/test_main.py
@@ -5,30 +5,37 @@ from unittest.mock import MagicMock, patch
 from bs4 import BeautifulSoup
 
 from main import (
+    _build_geocode_queries,
+    _normalize_address,
     _parse_location,
     _parse_section_fields,
+    _sanitize_database_url,
     _slugify,
+    backfill_missing_coordinates,
+    fetch_butecos_missing_coordinates,
     fs_create_session,
     fs_request,
     geocode_address,
     get_slugs,
     main,
+    parse_args,
+    resolve_database_url,
     scrape_buteco,
+    should_exit_with_error,
+    update_buteco_coordinates,
     upsert_buteco,
 )
-
-# ── _parse_location ──────────────────────────────────────────────────────────
 
 
 class TestParseLocation:
     def test_city_and_district(self):
-        cidade, bairro = _parse_location("Rua das Flores, 123, Santa Efigênia, Belo Horizonte")
+        cidade, bairro = _parse_location("Rua das Flores, 123, Santa Efigenia, Belo Horizonte")
         assert cidade == "Belo Horizonte"
-        assert bairro == "Santa Efigênia"
+        assert bairro == "Santa Efigenia"
 
     def test_strips_state_abbreviation(self):
-        cidade, bairro = _parse_location("Rua A, Centro, São Paulo, SP")
-        assert cidade == "São Paulo"
+        cidade, bairro = _parse_location("Rua A, Centro, Sao Paulo, SP")
+        assert cidade == "Sao Paulo"
         assert bairro == "Centro"
 
     def test_only_city_no_district(self):
@@ -46,24 +53,81 @@ class TestParseLocation:
         assert cidade == "Belo Horizonte"
         assert bairro == "Savassi"
 
+    def test_handles_pipe_and_state_dash_format(self):
+        cidade, bairro = _parse_location(
+            "R. Eduardo Tozzi, 115 | Jd. das Laranjeiras, Jaguariuna – SP"
+        )
+        assert cidade == "Jaguariuna"
+        assert bairro == "Jd. das Laranjeiras"
+
 
 class TestSlugify:
     def test_generates_slug_from_name(self):
-        assert _slugify("Bar do Zé & Filhos!") == "bar-do-ze-filhos"
+        assert _slugify("Bar do Ze & Filhos!") == "bar-do-ze-filhos"
 
 
-# ── _parse_section_fields ────────────────────────────────────────────────────
+class TestNormalizeAddress:
+    def test_normalizes_whitespace_and_cep(self):
+        endereco = " Rua A - 123,  Centro , Belo Horizonte , MG, CEP 30110-000 "
+        assert _normalize_address(endereco) == "Rua A, 123, Centro, Belo Horizonte, MG"
+
+    def test_normalizes_pipe_and_state_dash(self):
+        endereco = "R. Eduardo Tozzi, 115 | Jd. das Laranjeiras, Jaguariuna – SP"
+        assert _normalize_address(endereco) == (
+            "R. Eduardo Tozzi, 115, Jd. das Laranjeiras, Jaguariuna, SP"
+        )
+
+
+class TestBuildGeocodeQueries:
+    def test_generates_fallback_queries_without_duplicates(self):
+        queries = _build_geocode_queries(
+            "Rua A - 123, Centro, Belo Horizonte, MG",
+            cidade="Belo Horizonte",
+            bairro="Centro",
+        )
+
+        assert queries == [
+            "Rua A, 123, Centro, Belo Horizonte, MG",
+            "Rua A, 123, Centro, Belo Horizonte, MG, Belo Horizonte, Brasil",
+            "Belo Horizonte, MG",
+            "Centro, Belo Horizonte, Brasil",
+            "Belo Horizonte, Brasil",
+        ]
+
+
+class TestDatabaseUrl:
+    def test_sanitizes_pgbouncer_query_param(self):
+        url = "postgres://user:pass@host/db?sslmode=require&pgbouncer=true"
+        assert _sanitize_database_url(url) == "postgres://user:pass@host/db?sslmode=require"
+
+    @patch.dict(
+        "main.os.environ",
+        {
+            "POSTGRES_PRISMA_URL": "postgres://prisma/db?pgbouncer=true",
+            "DATABASE_URL": "postgres://database/db?sslmode=require",
+        },
+        clear=True,
+    )
+    def test_prefers_database_url_when_non_pooling_is_missing(self):
+        assert resolve_database_url() == "postgres://database/db?sslmode=require"
+
+    @patch.dict("main.os.environ", {}, clear=True)
+    def test_raises_when_no_database_url_exists(self):
+        try:
+            resolve_database_url()
+            raise AssertionError("resolve_database_url() deveria falhar sem env")
+        except RuntimeError as err:
+            assert "POSTGRES_URL_NON_POOLING" in str(err)
 
 
 def make_section(html: str):
-    """Wrap HTML in a div.section-text and return the BS4 element."""
     soup = BeautifulSoup(f"<div class='section-text'>{html}</div>", "html.parser")
     return soup.select_one(".section-text")
 
 
 class TestParseSectionFields:
     def test_parses_endereco(self):
-        section = make_section("<p><b>Endereço:</b> Rua das Flores, 10</p>")
+        section = make_section("<p><b>Endereco:</b> Rua das Flores, 10</p>")
         result = _parse_section_fields(section)
         assert result["endereco"] == "Rua das Flores, 10"
 
@@ -73,9 +137,9 @@ class TestParseSectionFields:
         assert result["telefone"] == "(31) 3333-4444"
 
     def test_parses_horario(self):
-        section = make_section("<p><b>Horário:</b> Seg a Sex, 18h às 23h</p>")
+        section = make_section("<p><b>Horario:</b> Seg a Sex, 18h as 23h</p>")
         result = _parse_section_fields(section)
-        assert result["horario"] == "Seg a Sex, 18h às 23h"
+        assert result["horario"] == "Seg a Sex, 18h as 23h"
 
     def test_parses_petisco_nome_and_desc(self):
         section = make_section(
@@ -94,16 +158,16 @@ class TestParseSectionFields:
     def test_full_section(self):
         html = (
             "<p><b>Pastel de Vento</b>: Fininho e crocante</p>"
-            "<p><b>Endereço:</b> Av. Brasil, 500, Centro, BH</p>"
+            "<p><b>Endereco:</b> Av. Brasil, 500, Centro, BH</p>"
             "<p><b>Telefone:</b> (31) 9999-0000</p>"
-            "<p><b>Horário:</b> Diário, 11h às 22h</p>"
+            "<p><b>Horario:</b> Diario, 11h as 22h</p>"
         )
         result = _parse_section_fields(make_section(html))
         assert result["petisco_nome"] == "Pastel de Vento"
         assert result["petisco_desc"] == "Fininho e crocante"
         assert result["endereco"] == "Av. Brasil, 500, Centro, BH"
         assert result["telefone"] == "(31) 9999-0000"
-        assert result["horario"] == "Diário, 11h às 22h"
+        assert result["horario"] == "Diario, 11h as 22h"
 
     def test_empty_section_returns_nones(self):
         section = make_section("")
@@ -118,9 +182,6 @@ class TestParseSectionFields:
         section = make_section("<p>Texto sem negrito</p>")
         result = _parse_section_fields(section)
         assert all(v is None for v in result.values())
-
-
-# ── fs_request ───────────────────────────────────────────────────────────────
 
 
 class TestFsRequest:
@@ -153,19 +214,24 @@ class TestGeocodeAddress:
         mock_resp = MagicMock()
         mock_resp.json.return_value = [{"lat": "-19.9167", "lon": "-43.9345"}]
         with patch("main.requests.get", return_value=mock_resp) as mock_get:
-            lat, lng = geocode_address("Rua A, Centro, Belo Horizonte")
+            lat, lng = geocode_address(
+                "Rua A, Centro, Belo Horizonte",
+                cidade="Belo Horizonte",
+                bairro="Centro",
+                sleep_seconds=0,
+            )
 
         assert lat == -19.9167
         assert lng == -43.9345
         mock_get.assert_called_once()
         _, kwargs = mock_get.call_args
         assert kwargs["params"]["q"] == "Rua A, Centro, Belo Horizonte"
-        assert kwargs["params"]["format"] == "json"
+        assert kwargs["params"]["format"] == "jsonv2"
         assert kwargs["params"]["limit"] == 1
 
     def test_returns_none_tuple_when_api_fails(self):
         with patch("main.requests.get", side_effect=RuntimeError("network down")):
-            lat, lng = geocode_address("Rua B, 10")
+            lat, lng = geocode_address("Rua B, 10", sleep_seconds=0)
         assert lat is None
         assert lng is None
 
@@ -173,9 +239,30 @@ class TestGeocodeAddress:
         mock_resp = MagicMock()
         mock_resp.json.return_value = []
         with patch("main.requests.get", return_value=mock_resp):
-            lat, lng = geocode_address("Rua sem resultado")
+            lat, lng = geocode_address("Rua sem resultado", sleep_seconds=0)
         assert lat is None
         assert lng is None
+
+    def test_tries_fallback_queries_until_one_succeeds(self):
+        first_resp = MagicMock()
+        first_resp.json.return_value = []
+        second_resp = MagicMock()
+        second_resp.json.return_value = [{"lat": "-19.9", "lon": "-43.9"}]
+
+        with (
+            patch("main.requests.get", side_effect=[first_resp, second_resp]) as mock_get,
+            patch("main.time.sleep") as mock_sleep,
+        ):
+            lat, lng = geocode_address(
+                "Rua A, 10, Centro, Belo Horizonte",
+                cidade="Belo Horizonte",
+                bairro="Centro",
+            )
+
+        assert lat == -19.9
+        assert lng == -43.9
+        assert mock_get.call_count == 2
+        mock_sleep.assert_called_once()
 
 
 class TestFsCreateSession:
@@ -184,13 +271,11 @@ class TestFsCreateSession:
             fs_create_session()
 
 
-# ── get_slugs ────────────────────────────────────────────────────────────────
-
 _SLUG_PAGE_HTML = """
 <html><body>
-  <a href="/buteco/bar-do-ze/">Bar do Zé</a>
+  <a href="/buteco/bar-do-ze/">Bar do Ze</a>
   <a href="/buteco/cantina-italiana/">Cantina</a>
-  <a href="/buteco/bar-do-ze/">Bar do Zé (dup)</a>
+  <a href="/buteco/bar-do-ze/">Bar do Ze (dup)</a>
   <a href="/outros/">outro</a>
 </body></html>
 """
@@ -213,17 +298,15 @@ class TestGetSlugs:
         assert slugs == []
 
 
-# ── scrape_buteco ────────────────────────────────────────────────────────────
-
 _BUTECO_HTML = """
 <html><body>
-  <h1 class="section-title">Bar do Zé</h1>
+  <h1 class="section-title">Bar do Ze</h1>
   <img class="img-single" src="https://example.com/foto.jpg">
   <div class="section-text">
     <p><b>Torresmo Artesanal</b>: Crocante e temperado</p>
-    <p><b>Endereço:</b> Rua A, 1, Floresta, Belo Horizonte, MG</p>
+    <p><b>Endereco:</b> Rua A, 1, Floresta, Belo Horizonte, MG</p>
     <p><b>Telefone:</b> (31) 3333-0000</p>
-    <p><b>Horário:</b> Ter a Dom, 17h às 23h</p>
+    <p><b>Horario:</b> Ter a Dom, 17h as 23h</p>
   </div>
 </body></html>
 """
@@ -233,11 +316,11 @@ class TestScrapeButeco:
     def test_parses_full_page(self):
         with (
             patch("main.fs_request", return_value=_BUTECO_HTML),
-            patch("main.geocode_address", return_value=(-19.9, -43.9)),
+            patch("main.geocode_address", return_value=(-19.9, -43.9)) as mock_geocode,
         ):
             data = scrape_buteco("bar-do-ze")
         assert data["slug"] == "bar-do-ze"
-        assert data["nome"] == "Bar do Zé"
+        assert data["nome"] == "Bar do Ze"
         assert data["cidade"] == "Belo Horizonte"
         assert data["bairro"] == "Floresta"
         assert "Rua A, 1" in data["endereco"]
@@ -248,6 +331,11 @@ class TestScrapeButeco:
         assert data["foto_url"] == "https://example.com/foto.jpg"
         assert data["lat"] == -19.9
         assert data["lng"] == -43.9
+        mock_geocode.assert_called_once_with(
+            "Rua A, 1, Floresta, Belo Horizonte, MG",
+            cidade="Belo Horizonte",
+            bairro="Floresta",
+        )
 
     def test_returns_empty_dict_when_no_html(self):
         with patch("main.fs_request", return_value=""):
@@ -265,7 +353,7 @@ class TestScrapeButeco:
             "<h1 class='section-title'>Buteco X</h1>"
             "<img class='img-single' data-src='https://cdn.example.com/lazy.jpg'>"
             "<div class='section-text'>"
-            "<p><b>Endereço:</b> Rua B, Centro, Rio de Janeiro</p>"
+            "<p><b>Endereco:</b> Rua B, Centro, Rio de Janeiro</p>"
             "</div></body></html>"
         )
         with (
@@ -287,8 +375,8 @@ class TestScrapeButeco:
     def test_generates_slug_from_name_when_input_slug_is_empty(self):
         html = (
             "<html><body>"
-            "<h1 class='section-title'>Cantina do João</h1>"
-            "<div class='section-text'><p><b>Endereço:</b> Rua C, Centro, Curitiba</p></div>"
+            "<h1 class='section-title'>Cantina do Joao</h1>"
+            "<div class='section-text'><p><b>Endereco:</b> Rua C, Centro, Curitiba</p></div>"
             "</body></html>"
         )
         with (
@@ -299,9 +387,6 @@ class TestScrapeButeco:
         assert data["slug"] == "cantina-do-joao"
 
 
-# ── upsert_buteco ────────────────────────────────────────────────────────────
-
-
 class TestUpsertButeco:
     def test_executes_upsert_and_commits(self):
         conn = MagicMock()
@@ -309,7 +394,7 @@ class TestUpsertButeco:
         conn.cursor.return_value.__enter__.return_value = cur_ctx
         data = {
             "slug": "bar-do-ze",
-            "nome": "Bar do Zé",
+            "nome": "Bar do Ze",
             "cidade": "Belo Horizonte",
             "bairro": "Floresta",
             "endereco": "Rua A, 1",
@@ -328,25 +413,89 @@ class TestUpsertButeco:
         sql, params = cur_ctx.execute.call_args[0]
         assert 'INSERT INTO "Buteco"' in sql
         assert "ON CONFLICT (slug) DO UPDATE SET" in sql
+        assert 'COALESCE(EXCLUDED.lat, "Buteco".lat)' in sql
+        assert 'COALESCE(EXCLUDED.lng, "Buteco".lng)' in sql
         assert params == data
         conn.commit.assert_called_once()
 
 
-# ── main ─────────────────────────────────────────────────────────────────────
+class TestBackfillCoordinates:
+    def test_fetches_only_records_with_missing_coordinates(self):
+        conn = MagicMock()
+        cur_ctx = MagicMock()
+        cur_ctx.fetchall.return_value = [("bar-do-ze", "Rua A, 1", "Belo Horizonte", "Floresta")]
+        conn.cursor.return_value.__enter__.return_value = cur_ctx
+
+        result = fetch_butecos_missing_coordinates(conn)
+
+        assert result == [
+            {
+                "slug": "bar-do-ze",
+                "endereco": "Rua A, 1",
+                "cidade": "Belo Horizonte",
+                "bairro": "Floresta",
+            }
+        ]
+
+    def test_updates_coordinates_and_commits(self):
+        conn = MagicMock()
+        cur_ctx = MagicMock()
+        cur_ctx.rowcount = 1
+        conn.cursor.return_value.__enter__.return_value = cur_ctx
+
+        updated = update_buteco_coordinates(conn, "bar-do-ze", -19.9, -43.9)
+
+        assert updated is True
+        cur_ctx.execute.assert_called_once()
+        conn.commit.assert_called_once()
+
+    def test_backfill_updates_only_successful_geocodes(self):
+        conn = MagicMock()
+        with (
+            patch(
+                "main.fetch_butecos_missing_coordinates",
+                return_value=[
+                    {
+                        "slug": "bar-1",
+                        "endereco": "Rua A, 1",
+                        "cidade": "Belo Horizonte",
+                        "bairro": "Floresta",
+                    },
+                    {
+                        "slug": "bar-2",
+                        "endereco": "Rua B, 2",
+                        "cidade": "Curitiba",
+                        "bairro": "Centro",
+                    },
+                ],
+            ),
+            patch("main.geocode_address", side_effect=[(-19.9, -43.9), (None, None)]),
+            patch("main.update_buteco_coordinates", return_value=True) as mock_update,
+        ):
+            updated, failed = backfill_missing_coordinates(conn)
+
+        assert updated == 1
+        assert failed == 1
+        mock_update.assert_called_once_with(conn, "bar-1", -19.9, -43.9)
+
+
+class TestCliAndExitRules:
+    def test_parses_backfill_flags(self):
+        args = parse_args(["--skip-scrape", "--backfill-missing-geocodes"])
+        assert args.skip_scrape is True
+        assert args.backfill_missing_geocodes is True
+
+    def test_exit_rule_requires_failure_without_any_success(self):
+        assert should_exit_with_error(0, 1, False, 0, 0) is True
+        assert should_exit_with_error(0, 1, True, 0, 1) is True
+        assert should_exit_with_error(1, 1, False, 0, 0) is False
+        assert should_exit_with_error(0, 1, True, 1, 0) is False
 
 
 class TestMainLoop:
-    @patch.dict("main.os.environ", {}, clear=True)
-    def test_raises_when_database_url_is_missing(self):
-        try:
-            main()
-            raise AssertionError("main() deveria falhar sem POSTGRES_URL_NON_POOLING")
-        except RuntimeError as err:
-            assert "POSTGRES_URL_NON_POOLING não definida" in str(err)
-
-    @patch.dict("main.os.environ", {"POSTGRES_URL_NON_POOLING": "postgres://example"}, clear=True)
     @patch("main.time.sleep")
     @patch("main.psycopg2.connect")
+    @patch("main.resolve_database_url", return_value="postgres://example")
     @patch("main.fs_create_session")
     @patch("main.upsert_buteco")
     @patch("main.scrape_buteco")
@@ -357,6 +506,7 @@ class TestMainLoop:
         mock_scrape_buteco,
         mock_upsert_buteco,
         _mock_fs_create_session,
+        _mock_resolve_database_url,
         mock_connect,
         mock_sleep,
     ):
@@ -375,9 +525,9 @@ class TestMainLoop:
         assert mock_upsert_buteco.call_count == 2
         conn.close.assert_called_once()
 
-    @patch.dict("main.os.environ", {"POSTGRES_URL_NON_POOLING": "postgres://example"}, clear=True)
     @patch("main.time.sleep")
     @patch("main.psycopg2.connect")
+    @patch("main.resolve_database_url", return_value="postgres://example")
     @patch("main.fs_create_session")
     @patch("main.upsert_buteco")
     @patch("main.scrape_buteco")
@@ -390,6 +540,7 @@ class TestMainLoop:
         mock_scrape_buteco,
         _mock_upsert_buteco,
         _mock_fs_create_session,
+        _mock_resolve_database_url,
         mock_connect,
         _mock_sleep,
     ):
@@ -401,9 +552,9 @@ class TestMainLoop:
 
         mock_exit.assert_called_once_with(1)
 
-    @patch.dict("main.os.environ", {"POSTGRES_URL_NON_POOLING": "postgres://example"}, clear=True)
     @patch("main.time.sleep")
     @patch("main.psycopg2.connect")
+    @patch("main.resolve_database_url", return_value="postgres://example")
     @patch("main.fs_create_session")
     @patch("main.upsert_buteco", side_effect=RuntimeError("db down"))
     @patch("main.scrape_buteco")
@@ -416,6 +567,7 @@ class TestMainLoop:
         mock_scrape_buteco,
         _mock_upsert_buteco,
         _mock_fs_create_session,
+        _mock_resolve_database_url,
         mock_connect,
         _mock_sleep,
     ):
@@ -433,3 +585,20 @@ class TestMainLoop:
 
         conn.rollback.assert_called_once()
         mock_exit.assert_called_once_with(1)
+
+    @patch("main.backfill_missing_coordinates", return_value=(2, 1))
+    @patch("main.psycopg2.connect")
+    @patch("main.resolve_database_url", return_value="postgres://example")
+    def test_runs_backfill_when_flag_is_enabled(
+        self,
+        _mock_resolve_database_url,
+        mock_connect,
+        mock_backfill,
+    ):
+        conn = MagicMock()
+        mock_connect.return_value = conn
+
+        main(["--skip-scrape", "--backfill-missing-geocodes"])
+
+        mock_backfill.assert_called_once_with(conn)
+        conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- Normalize real-world address formats before geocoding and add fallback Nominatim queries.
- Preserve valid coordinates on upsert and add a manual backfill path for records missing `lat/lng`.
- Document the backfill command and cover the new flow with scraper tests.

Closes #46

## Testing
- `python -m pytest scraper\tests\test_main.py`
- `python -m py_compile scraper\main.py scraper\tests\test_main.py`
