### PR TITLE
chore: adicionar dispatch manual ao scraper

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:
+    inputs:
+      mode:
+        description: "Modo de execucao"
+        required: true
+        default: "backfill-only"
+        type: choice
+        options:
+          - backfill-only
+          - scrape-and-backfill
 
 # Mínimo de permissões para o GITHUB_TOKEN — o scraper não precisa escrever no repo
 permissions:
@@ -49,7 +58,13 @@ jobs:
 
       # O secret nunca é impresso — passado apenas como variável de ambiente
       # do processo filho, não aparece em logs nem em env do runner principal
-      - name: Rodar scraper
+      - name: Rodar scraper ou backfill
         env:
           POSTGRES_URL_NON_POOLING: ${{ secrets.POSTGRES_URL_NON_POOLING }}
-        run: python scraper/main.py
+          SCRAPER_MODE: ${{ github.event.inputs.mode || 'scrape-and-backfill' }}
+        run: |
+          if [ "$SCRAPER_MODE" = "backfill-only" ]; then
+            python scraper/main.py --skip-scrape --backfill-missing-geocodes
+          else
+            python scraper/main.py --backfill-missing-geocodes
+          fi


### PR DESCRIPTION
## Summary
- Add manual workflow inputs to the scraper action so GitHub Actions can run either backfill-only or scrape-and-backfill on demand.
- Keep the weekly scheduled execution intact while defaulting scheduled/manual full runs to scrape plus backfill.
- Reuse the existing database secret and keep the workflow behavior self-documented in YAML.

Closes #48

## Testing
- Validated the workflow YAML structure locally with Python.
