### PR TITLE
feat: adiciona navegação sessão-ciente com acesso a Minha Conta e logout

### DIFF
--- a/apps/web/app/(private)/layout.tsx
+++ b/apps/web/app/(private)/layout.tsx
@@ -1,0 +1,10 @@
+import Header from "@/components/ui/header";
+
+export default function PrivateLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+}

--- a/apps/web/app/(public)/layout.tsx
+++ b/apps/web/app/(public)/layout.tsx
@@ -1,0 +1,10 @@
+import Header from "@/components/ui/header";
+
+export default function PublicLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+}

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { MapaButecosShell } from "@/components/mapa/mapa-butecos-shell";
 import { prisma } from "@/lib/prisma";
 
@@ -50,33 +49,7 @@ export default async function Home() {
   const { total, butecosComMapa } = await getHomeData();
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 px-4 py-5 sm:gap-8 sm:px-6 sm:py-8 lg:px-8">
-      <header className="rounded-3xl border border-zinc-200 bg-white px-4 py-4 shadow-sm sm:px-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-              Comida di Buteco
-            </p>
-            <p className="text-2xl font-black tracking-tight text-zinc-900">Onde Tem Buteco</p>
-          </div>
-
-          <nav className="grid grid-cols-2 gap-2 sm:flex sm:items-center">
-            <Link
-              href="/butecos"
-              className="rounded-full border border-zinc-200 px-4 py-2 text-center text-sm font-semibold text-zinc-700 transition hover:border-amber-300 hover:bg-amber-50"
-            >
-              Ver botecos
-            </Link>
-            <Link
-              href="/login"
-              className="rounded-full bg-amber-500 px-4 py-2 text-center text-sm font-semibold text-white transition hover:bg-amber-600"
-            >
-              Login
-            </Link>
-          </nav>
-        </div>
-      </header>
-
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-5 sm:gap-8 sm:px-6 sm:py-8 lg:px-8">
       <section className="rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm sm:p-7">
         <h1 className="text-3xl font-black leading-tight tracking-tight text-zinc-900 sm:text-4xl">
           Descubra os botecos no mapa

--- a/apps/web/components/ui/header.tsx
+++ b/apps/web/components/ui/header.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { auth, signOut } from "@/lib/auth";
+
+export default async function Header() {
+  const session = await auth();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 pt-5 sm:px-6 sm:pt-8 lg:px-8">
+      <header className="rounded-3xl border border-zinc-200 bg-white px-4 py-4 shadow-sm sm:px-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <Link href="/">
+            <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+              Comida di Buteco
+            </p>
+            <p className="text-2xl font-black tracking-tight text-zinc-900">Onde Tem Buteco</p>
+          </Link>
+
+          <nav className="flex flex-wrap items-center gap-2">
+            <Link
+              href="/butecos"
+              className="rounded-full border border-zinc-200 px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:border-amber-300 hover:bg-amber-50"
+            >
+              Ver botecos
+            </Link>
+            {session ? (
+              <>
+                <Link
+                  href="/minha-conta"
+                  className="rounded-full border border-zinc-200 px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:border-amber-300 hover:bg-amber-50"
+                >
+                  Minha Conta
+                </Link>
+                <form
+                  action={async () => {
+                    "use server";
+                    await signOut({ redirectTo: "/" });
+                  }}
+                >
+                  <button
+                    type="submit"
+                    className="rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600"
+                  >
+                    Sair
+                  </button>
+                </form>
+              </>
+            ) : (
+              <Link
+                href="/login"
+                className="rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600"
+              >
+                Login
+              </Link>
+            )}
+          </nav>
+        </div>
+      </header>
+    </div>
+  );
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,7 +15,7 @@ sonar.exclusions=**/node_modules/**,**/.next/**,**/generated/**,**/__pycache__/*
 
 # TypeScript
 sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info
-sonar.coverage.exclusions=apps/web/app/**/page.tsx,apps/web/app/layout.tsx,apps/web/lib/auth.ts,apps/web/lib/prisma.ts,apps/web/app/api/auth/[...nextauth]/route.ts
+sonar.coverage.exclusions=apps/web/app/**/page.tsx,apps/web/app/**/layout.tsx,apps/web/lib/auth.ts,apps/web/lib/prisma.ts,apps/web/app/api/auth/[...nextauth]/route.ts
 
 # Python
 sonar.python.version=3.12


### PR DESCRIPTION
Cria componente Header compartilhado (Server Component) que detecta a
sessão via auth() e adapta a navegação: anônimos veem o CTA de Login,
autenticados veem atalhos para Minha Conta e botão Sair com server action.

Aplica o Header via layouts dos grupos (public) e (private), garantindo
consistência entre home, listagem, detalhe e página de conta.

Closes #41

https://claude.ai/code/session_01NAnazCsW1ZCLGzs9VCjdAW