### PR TITLE
feat: adiciona filtro dinâmico de bairros ao trocar cidade em /butecos

### DIFF
--- a/apps/web/app/(public)/butecos/page.tsx
+++ b/apps/web/app/(public)/butecos/page.tsx
@@ -1,10 +1,12 @@
 import Link from "next/link";
+import { Suspense } from "react";
 import {
   buildButecoWhere,
   countActiveButecoFilters,
   normalizeButecoFilters,
 } from "@/lib/buteco-filters";
 import { prisma } from "@/lib/prisma";
+import { ButecosFilterForm } from "@/components/butecos/filter-form";
 
 export default async function ButecosPage({
   searchParams,
@@ -69,68 +71,13 @@ export default async function ButecosPage({
       </section>
 
       <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm">
-        <form className="grid gap-4 sm:grid-cols-2 lg:grid-cols-[1.2fr_1fr_1fr_auto_auto] lg:items-end">
-          <label className="flex min-w-0 flex-col gap-2 sm:col-span-2 lg:col-span-1">
-            <span className="text-sm font-semibold text-zinc-800">Buscar</span>
-            <input
-              name="q"
-              defaultValue={filters.q ?? ""}
-              placeholder="Nome do buteco ou petisco"
-              className="w-full rounded-2xl border border-zinc-200 px-4 py-3 text-sm text-zinc-900 outline-none transition focus:border-amber-400"
-            />
-          </label>
-
-          <label className="flex min-w-0 flex-col gap-2">
-            <span className="text-sm font-semibold text-zinc-800">Cidade</span>
-            <select
-              name="cidade"
-              defaultValue={filters.cidade ?? ""}
-              className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 outline-none transition focus:border-amber-400"
-            >
-              <option value="">Todas as cidades</option>
-              {cidadeOptions.map((cidade) => (
-                <option key={cidade} value={cidade}>
-                  {cidade}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="flex min-w-0 flex-col gap-2">
-            <span className="text-sm font-semibold text-zinc-800">Bairro</span>
-            <select
-              name="bairro"
-              defaultValue={filters.bairro ?? ""}
-              className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 outline-none transition focus:border-amber-400 disabled:cursor-not-allowed disabled:bg-zinc-100 disabled:text-zinc-400"
-              disabled={bairroOptions.length === 0}
-            >
-              <option value="">Todos os bairros</option>
-              {bairroOptions.map((bairro) => (
-                <option key={bairro} value={bairro}>
-                  {bairro}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <button
-            type="submit"
-            className="rounded-2xl bg-amber-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-amber-600"
-          >
-            Aplicar filtros
-          </button>
-
-          <Link
-            href="/butecos"
-            className="rounded-2xl border border-zinc-200 px-5 py-3 text-center text-sm font-semibold text-zinc-700 transition hover:border-amber-300 hover:bg-amber-50"
-          >
-            Limpar
-          </Link>
-        </form>
+        <Suspense>
+          <ButecosFilterForm cidadeOptions={cidadeOptions} bairroOptions={bairroOptions} />
+        </Suspense>
 
         {filters.cidade && bairroOptions.length === 0 ? (
           <p className="mt-4 text-sm text-zinc-500">
-            Ainda nÃ£o existem bairros cadastrados para a cidade selecionada.
+            Ainda não existem bairros cadastrados para a cidade selecionada.
           </p>
         ) : null}
       </section>
@@ -172,7 +119,7 @@ export default async function ButecosPage({
                 {b.petiscoNome ? (
                   <p className="mt-3 text-sm font-medium text-amber-700">{b.petiscoNome}</p>
                 ) : (
-                  <p className="mt-3 text-sm text-zinc-400">Petisco ainda nÃ£o informado</p>
+                  <p className="mt-3 text-sm text-zinc-400">Petisco ainda não informado</p>
                 )}
               </Link>
             </li>

--- a/apps/web/components/butecos/filter-form.tsx
+++ b/apps/web/components/butecos/filter-form.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+
+type Props = {
+  cidadeOptions: string[];
+  bairroOptions: string[];
+};
+
+export function ButecosFilterForm({ cidadeOptions, bairroOptions }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const q = searchParams.get("q") ?? "";
+  const cidade = searchParams.get("cidade") ?? "";
+  const bairro = searchParams.get("bairro") ?? "";
+
+  function onCidadeChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const params = new URLSearchParams();
+    const newCidade = e.target.value;
+    if (newCidade) params.set("cidade", newCidade);
+    if (q) params.set("q", q);
+    const query = params.toString();
+    router.push(`/butecos${query ? `?${query}` : ""}`);
+  }
+
+  return (
+    <form className="grid gap-4 sm:grid-cols-2 lg:grid-cols-[1.2fr_1fr_1fr_auto_auto] lg:items-end">
+      <label className="flex min-w-0 flex-col gap-2 sm:col-span-2 lg:col-span-1">
+        <span className="text-sm font-semibold text-zinc-800">Buscar</span>
+        <input
+          name="q"
+          defaultValue={q}
+          placeholder="Nome do buteco ou petisco"
+          className="w-full rounded-2xl border border-zinc-200 px-4 py-3 text-sm text-zinc-900 outline-none transition focus:border-amber-400"
+        />
+      </label>
+
+      <label className="flex min-w-0 flex-col gap-2">
+        <span className="text-sm font-semibold text-zinc-800">Cidade</span>
+        <select
+          name="cidade"
+          value={cidade}
+          onChange={onCidadeChange}
+          className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 outline-none transition focus:border-amber-400"
+        >
+          <option value="">Todas as cidades</option>
+          {cidadeOptions.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex min-w-0 flex-col gap-2">
+        <span className="text-sm font-semibold text-zinc-800">Bairro</span>
+        <select
+          key={cidade}
+          name="bairro"
+          defaultValue={bairro}
+          disabled={bairroOptions.length === 0}
+          className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 outline-none transition focus:border-amber-400 disabled:cursor-not-allowed disabled:bg-zinc-100 disabled:text-zinc-400"
+        >
+          <option value="">Todos os bairros</option>
+          {bairroOptions.map((b) => (
+            <option key={b} value={b}>
+              {b}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <button
+        type="submit"
+        className="rounded-2xl bg-amber-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-amber-600"
+      >
+        Aplicar filtros
+      </button>
+
+      <Link
+        href="/butecos"
+        className="rounded-2xl border border-zinc-200 px-5 py-3 text-center text-sm font-semibold text-zinc-700 transition hover:border-amber-300 hover:bg-amber-50"
+      >
+        Limpar
+      </Link>
+    </form>
+  );
+}

--- a/apps/web/lib/__tests__/buteco-filters.test.ts
+++ b/apps/web/lib/__tests__/buteco-filters.test.ts
@@ -49,4 +49,37 @@ describe("buteco-filters", () => {
       })
     ).toBe(2);
   });
+
+  it("counts all three active filters", () => {
+    expect(
+      countActiveButecoFilters({
+        cidade: "Belo Horizonte",
+        bairro: "Centro",
+        q: "torresmo",
+      })
+    ).toBe(3);
+  });
+
+  it("returns zero when all filters are empty or whitespace", () => {
+    expect(countActiveButecoFilters({ cidade: "  ", bairro: "", q: undefined })).toBe(0);
+  });
+
+  it("builds where clause with only q, no city or neighborhood", () => {
+    expect(buildButecoWhere({ q: "feijoada" })).toEqual({
+      OR: [
+        { nome: { contains: "feijoada", mode: "insensitive" } },
+        { petiscoNome: { contains: "feijoada", mode: "insensitive" } },
+      ],
+    });
+  });
+
+  it("builds where clause with only city, no neighborhood or q", () => {
+    expect(buildButecoWhere({ cidade: "São Paulo" })).toEqual({ cidade: "São Paulo" });
+  });
+
+  it("ignores bairro when city is not set (whitespace city)", () => {
+    expect(buildButecoWhere({ cidade: "   ", bairro: "Centro" })).toEqual({
+      bairro: "Centro",
+    });
+  });
 });


### PR DESCRIPTION
Extrai o formulário de filtros para um Client Component (ButecosFilterForm)
que usa useSearchParams + useRouter para atualizar a URL automaticamente
ao trocar de cidade, limpando o bairro selecionado e acionando o recarregamento
dos bairros da nova cidade sem precisar clicar em "Aplicar filtros".

Também corrige dois textos mojibake na listagem e amplia os testes
de buteco-filters com casos de borda adicionais.

Closes #43

https://claude.ai/code/session_014Jbo1Nb5BnsmR5fo1VhhiD