### PR TITLE
docs: atualiza README, AGENTS e CLAUDE com convenções de GitHub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,12 @@ DATABASE_URL=<url> python main.py
 2. Verificar se existe issue ou task relacionada
 3. Criar branch a partir de `main` com nome descritivo: `feat/mapa-leaflet`, `fix/filtro-bairro`
 
+### Issues
+- Toda issue nova deve receber `labels`, `milestone` e `project`
+- Toda issue deve representar uma unidade de trabalho rastreável antes da abertura do PR
+- No project `Onde Tem Buteco`, manter apenas issues como itens visíveis
+- Pull requests não devem permanecer como itens do project; a ligação deve aparecer pela coluna `Linked pull requests` da issue
+
 ### Commits
 Seguir Conventional Commits:
 ```
@@ -220,6 +226,9 @@ docs: atualiza AGENTS.md com instruções do scraper
 ### Pull Requests
 - PRs pequenos e focados — uma funcionalidade por PR
 - Descrever o que foi feito e como testar
+- Todo PR deve estar vinculado à issue correspondente no corpo da descrição, preferencialmente com `Closes #numero` ou `Fixes #numero` quando o merge resolver a issue
+- Todo PR deve receber as labels, milestone e project adequados ao escopo da entrega
+- PRs complementares devem usar `Refs #numero` quando fizerem parte da mesma entrega sem encerrar a issue principal
 - Vercel cria preview deploy automático por PR
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,12 @@ DATABASE_URL=<url> python main.py
 2. Verificar se existe issue ou task relacionada
 3. Criar branch a partir de `main` com nome descritivo: `feat/mapa-leaflet`, `fix/filtro-bairro`
 
+### Issues
+- Toda issue nova deve receber `labels`, `milestone` e `project`
+- Toda issue deve representar uma unidade de trabalho rastreável antes da abertura do PR
+- No project `Onde Tem Buteco`, manter apenas issues como itens visíveis
+- Pull requests não devem permanecer como itens do project; a ligação deve aparecer pela coluna `Linked pull requests` da issue
+
 ### Commits
 Seguir Conventional Commits:
 ```
@@ -220,6 +226,9 @@ docs: atualiza CLAUDE.md com instruções do scraper
 ### Pull Requests
 - PRs pequenos e focados — uma funcionalidade por PR
 - Descrever o que foi feito e como testar
+- Todo PR deve estar vinculado à issue correspondente no corpo da descrição, preferencialmente com `Closes #numero` ou `Fixes #numero` quando o merge resolver a issue
+- Todo PR deve receber as labels, milestone e project adequados ao escopo da entrega
+- PRs complementares devem usar `Refs #numero` quando fizerem parte da mesma entrega sem encerrar a issue principal
 - Vercel cria preview deploy automático por PR
 
 ---

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@
 
 | Camada | Tecnologia |
 |---|---|
-| Framework | Next.js 15 (App Router) + TypeScript |
+| Framework | Next.js 16 (App Router) + TypeScript |
 | Estilização | Tailwind CSS |
 | ORM | Prisma |
 | Banco de dados | Vercel Postgres (Neon) |
 | Autenticação | NextAuth.js v5 (Google OAuth) |
 | Mapa | Leaflet.js |
-| Scraper | Python 3.12 + BeautifulSoup |
+| Scraper | Python 3.12 + BeautifulSoup + psycopg2 |
 | CI/CD | GitHub Actions |
 | Hospedagem | Vercel |
 
@@ -127,7 +127,19 @@ Veja o arquivo [`.env.example`](.env.example) para a lista completa com instruç
 1. Fork o repositório
 2. Crie uma branch: `git checkout -b feat/minha-feature`
 3. Commit seguindo [Conventional Commits](https://www.conventionalcommits.org/): `feat: adiciona filtro por bairro`
-4. Abra um Pull Request descrevendo o que foi feito e como testar
+4. Crie ou identifique a issue relacionada antes de abrir o PR
+5. Ao criar a issue, preencha `labels`, `milestone` e `project`
+6. Abra um Pull Request descrevendo o que foi feito e como testar
+7. No corpo do PR, vincule a issue com `Closes #numero`, `Fixes #numero` ou `Refs #numero`
+8. Preencha no PR os `labels`, `milestone` e `project` adequados
+
+### Convenções de GitHub
+
+- O project deve conter apenas issues como itens visíveis
+- Pull requests não devem permanecer como linhas próprias no project
+- O relacionamento entre issue e PR deve aparecer pela coluna `Linked pull requests`
+- Use `Closes` ou `Fixes` apenas no PR principal que realmente encerra a issue
+- Use `Refs` em PRs complementares que façam parte do mesmo trabalho, sem fechar a issue novamente
 
 Para agentes de IA e colaboradores: leia o [`CLAUDE.md`](CLAUDE.md) antes de começar.
 


### PR DESCRIPTION
## Summary
- atualiza o README com a stack correta e com o fluxo de contribui��o baseado em issue antes do PR
- registra em AGENTS.md e CLAUDE.md as regras de labels, milestone, project e v�nculo entre issue e PR
- documenta que o project deve manter apenas issues como itens vis�veis e usar a coluna `Linked pull requests` para rastrear PRs

Closes #38

## Testing
- altera��o documental; n�o exigiu testes de runtime
