### PR TITLE
Add Playwright e2e coverage for public flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@
 # ============================================================
 
 # ----------------------------------------------------------
-# Banco de dados (Vercel Postgres / Neon)
-# Obtido no painel da Vercel: Storage > seu banco > .env.local
+# Banco de dados (Supabase Postgres)
+# Obtido no painel do Supabase: Project Settings > Database
 # ----------------------------------------------------------
 DATABASE_URL=
 POSTGRES_URL=

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -116,12 +116,41 @@ jobs:
           name: coverage-typescript
           path: apps/web/coverage/lcov.info
 
+  e2e-typescript:
+    name: E2E tests (TypeScript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: apps/web
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install Playwright browsers
+        working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        working-directory: apps/web
+        run: pnpm test:e2e
+
   # ── SonarCloud: qualidade agregada (dívida técnica, duplicação, cobertura) ─
   sonarcloud:
     name: Quality gate (SonarCloud)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [coverage-python, coverage-typescript]
+    needs: [coverage-python, coverage-typescript, e2e-typescript]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,12 @@ docs: atualiza AGENTS.md com instruções do scraper
 - Descrever o que foi feito e como testar
 - Vercel cria preview deploy automático por PR
 
+### Issues
+- Issues criadas por agentes de IA devem ser atribuídas a `@gianimpronta` no momento da criação
+- Ao desmembrar uma issue em sub-issues, manter a atribuição em `@gianimpronta` por padrão
+- Não é necessário workflow de auto-assign enquanto esse fluxo continuar estável
+- Se o projeto passar a ter múltiplos responsáveis abrindo issues com frequência, reavaliar essa convenção
+
 ---
 
 ## Fases do MVP

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ devem ser alterados manualmente no banco.
 | Framework | Next.js 16 (App Router) + TypeScript |
 | Estilização | Tailwind CSS |
 | ORM | Prisma |
-| Banco de dados | Vercel Postgres (Neon) |
+| Banco de dados | Supabase Postgres |
 | Autenticação | NextAuth.js v5 (Google OAuth) |
 | Mapa | Leaflet.js |
 | Scraper | Python 3.12 + BeautifulSoup + psycopg2 |
@@ -155,6 +155,27 @@ GOOGLE_CLIENT_SECRET=
 
 O scraper usa apenas `DATABASE_URL`, injetada via GitHub Actions Secret.
 
+## Comandos úteis de infraestrutura
+
+### Vercel
+- `vercel link`
+- `vercel env pull .env.local`
+- `vercel pull`
+
+### Supabase
+- `supabase link --project-ref <project-ref>`
+- `supabase db pull`
+- `supabase db push`
+- `supabase secrets set --env-file .env.local`
+
+### GitHub
+- `gh auth status`
+- `gh issue view <numero>`
+- `gh issue create`
+- `gh pr create --draft`
+- `gh pr view --web`
+- `gh run list`
+
 ---
 
 ## Scraper
@@ -239,7 +260,7 @@ docs: atualiza AGENTS.md com instruções do scraper
 
 ### Fase 1 — Dados ✅ (base)
 - [ ] Setup Next.js 16 + TypeScript + Tailwind + Prisma
-- [ ] Configurar Vercel Postgres
+- [ ] Configurar Supabase Postgres
 - [ ] Rodar scraper manualmente para popular o banco
 - [ ] Migrations iniciais
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,11 @@ docs: atualiza AGENTS.md com instruções do scraper
 - Descrever o que foi feito e como testar
 - Vercel cria preview deploy automático por PR
 
+### Antes de push
+- Sempre rodar `format`, `lint`, `test` e `e2e` antes de qualquer `git push`
+- Não fazer push com qualquer uma dessas etapas falhando
+- Ao descrever validação em PRs, incluir de forma objetiva que essas quatro etapas foram executadas
+
 ### Issues
 - Issues criadas por agentes de IA devem ser atribuídas a `@gianimpronta` no momento da criação
 - Ao desmembrar uma issue em sub-issues, manter a atribuição em `@gianimpronta` por padrão

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,17 +27,17 @@ devem ser alterados manualmente no banco.
 
 ## Stack
 
-| Camada | Tecnologia |
-|---|---|
-| Framework | Next.js 16 (App Router) + TypeScript |
-| Estilização | Tailwind CSS |
-| ORM | Prisma |
-| Banco de dados | Supabase Postgres |
-| Autenticação | NextAuth.js v5 (Google OAuth) |
-| Mapa | Leaflet.js |
-| Scraper | Python 3.12 + BeautifulSoup + psycopg2 |
-| CI/CD | GitHub Actions |
-| Hospedagem | Vercel |
+| Camada         | Tecnologia                             |
+| -------------- | -------------------------------------- |
+| Framework      | Next.js 16 (App Router) + TypeScript   |
+| Estilização    | Tailwind CSS                           |
+| ORM            | Prisma                                 |
+| Banco de dados | Supabase Postgres                      |
+| Autenticação   | NextAuth.js v5 (Google OAuth)          |
+| Mapa           | Leaflet.js                             |
+| Scraper        | Python 3.12 + BeautifulSoup + psycopg2 |
+| CI/CD          | GitHub Actions                         |
+| Hospedagem     | Vercel                                 |
 
 ---
 
@@ -158,17 +158,20 @@ O scraper usa apenas `DATABASE_URL`, injetada via GitHub Actions Secret.
 ## Comandos úteis de infraestrutura
 
 ### Vercel
+
 - `vercel link`
 - `vercel env pull .env.local`
 - `vercel pull`
 
 ### Supabase
+
 - `supabase link --project-ref <project-ref>`
 - `supabase db pull`
 - `supabase db push`
 - `supabase secrets set --env-file .env.local`
 
 ### GitHub
+
 - `gh auth status`
 - `gh issue view <numero>`
 - `gh issue create`
@@ -199,6 +202,7 @@ DATABASE_URL=<url> python main.py
 ## Convenções de código
 
 ### Geral
+
 - TypeScript strict mode sempre ativado — sem `any`
 - Funções e variáveis em `camelCase`
 - Componentes React em `PascalCase`
@@ -206,17 +210,20 @@ DATABASE_URL=<url> python main.py
 - Sem comentários óbvios — o código deve ser autodescritivo
 
 ### Next.js
+
 - Preferir Server Components por padrão
 - Client Components (`"use client"`) apenas quando necessário (interatividade, hooks)
 - Dados sempre buscados no servidor via Prisma — nunca expor o client do Prisma no browser
 - Rotas de API apenas para mutações (POST/DELETE de favoritos e visitas)
 
 ### Prisma
+
 - Sempre usar o singleton de `lib/prisma.ts`
 - Nunca usar `prisma.$queryRaw` — usar a API do Prisma
 - Migrations via `prisma migrate dev` em desenvolvimento
 
 ### Tailwind
+
 - Sem CSS customizado — usar apenas classes utilitárias do Tailwind
 - Componentes reutilizáveis extraídos para `components/ui/`
 
@@ -225,12 +232,15 @@ DATABASE_URL=<url> python main.py
 ## Fluxo de desenvolvimento
 
 ### Antes de começar qualquer tarefa
+
 1. Ler este arquivo
 2. Verificar se existe issue ou task relacionada
 3. Criar branch a partir de `main` com nome descritivo: `feat/mapa-leaflet`, `fix/filtro-bairro`
 
 ### Commits
+
 Seguir Conventional Commits:
+
 ```
 feat: adiciona mapa interativo com Leaflet
 fix: corrige filtro por bairro no Rio
@@ -239,16 +249,19 @@ docs: atualiza AGENTS.md com instruções do scraper
 ```
 
 ### Pull Requests
+
 - PRs pequenos e focados — uma funcionalidade por PR
 - Descrever o que foi feito e como testar
 - Vercel cria preview deploy automático por PR
 
 ### Antes de push
+
 - Sempre rodar `format`, `lint`, `test` e `e2e` antes de qualquer `git push`
 - Não fazer push com qualquer uma dessas etapas falhando
 - Ao descrever validação em PRs, incluir de forma objetiva que essas quatro etapas foram executadas
 
 ### Issues
+
 - Issues criadas por agentes de IA devem ser atribuídas a `@gianimpronta` no momento da criação
 - Ao desmembrar uma issue em sub-issues, manter a atribuição em `@gianimpronta` por padrão
 - Não é necessário workflow de auto-assign enquanto esse fluxo continuar estável
@@ -259,24 +272,28 @@ docs: atualiza AGENTS.md com instruções do scraper
 ## Fases do MVP
 
 ### Fase 1 — Dados ✅ (base)
+
 - [ ] Setup Next.js 16 + TypeScript + Tailwind + Prisma
 - [ ] Configurar Supabase Postgres
 - [ ] Rodar scraper manualmente para popular o banco
 - [ ] Migrations iniciais
 
 ### Fase 2 — Leitura
+
 - [ ] Listagem de butecos com filtro por cidade e bairro
 - [ ] Busca por nome
 - [ ] Página de detalhe do buteco
 - [ ] Mapa interativo com Leaflet
 
 ### Fase 3 — Usuário
+
 - [ ] Google OAuth via NextAuth
 - [ ] Favoritar buteco
 - [ ] Marcar como visitado
 - [ ] Página "Minha Conta" com favoritos e histórico
 
 ### Fase 4 — Produção
+
 - [ ] SEO básico (metadata, Open Graph, sitemap.xml)
 - [ ] Deploy na Vercel
 - [ ] Configurar GitHub Actions cron do scraper
@@ -299,13 +316,13 @@ Este repositório é **público**. Qualquer pessoa pode ler o código.
 
 ## Arquivos obrigatórios no repositório
 
-| Arquivo | Propósito |
-|---|---|
-| `.gitignore` | Ignorar `.env.local`, `.env`, `node_modules/`, `.next/`, `__pycache__/` |
-| `.env.example` | Documentar todas as variáveis necessárias com valores vazios |
-| `README.md` | Descrição, como rodar localmente, stack e créditos |
-| `LICENSE` | MIT — uso livre com atribuição |
-| `AGENTS.md` | Este arquivo — guia para agentes de IA e colaboradores |
+| Arquivo        | Propósito                                                               |
+| -------------- | ----------------------------------------------------------------------- |
+| `.gitignore`   | Ignorar `.env.local`, `.env`, `node_modules/`, `.next/`, `__pycache__/` |
+| `.env.example` | Documentar todas as variáveis necessárias com valores vazios            |
+| `README.md`    | Descrição, como rodar localmente, stack e créditos                      |
+| `LICENSE`      | MIT — uso livre com atribuição                                          |
+| `AGENTS.md`    | Este arquivo — guia para agentes de IA e colaboradores                  |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ devem ser alterados manualmente no banco.
 | Framework | Next.js 16 (App Router) + TypeScript |
 | Estilização | Tailwind CSS |
 | ORM | Prisma |
-| Banco de dados | Vercel Postgres (Neon) |
+| Banco de dados | Supabase Postgres |
 | Autenticação | NextAuth.js v5 (Google OAuth) |
 | Mapa | Leaflet.js |
 | Scraper | Python 3.12 + BeautifulSoup + psycopg2 |
@@ -155,6 +155,27 @@ GOOGLE_CLIENT_SECRET=
 
 O scraper usa apenas `DATABASE_URL`, injetada via GitHub Actions Secret.
 
+## Comandos úteis de infraestrutura
+
+### Vercel
+- `vercel link`
+- `vercel env pull .env.local`
+- `vercel pull`
+
+### Supabase
+- `supabase link --project-ref <project-ref>`
+- `supabase db pull`
+- `supabase db push`
+- `supabase secrets set --env-file .env.local`
+
+### GitHub
+- `gh auth status`
+- `gh issue view <numero>`
+- `gh issue create`
+- `gh pr create --draft`
+- `gh pr view --web`
+- `gh run list`
+
 ---
 
 ## Scraper
@@ -239,7 +260,7 @@ docs: atualiza CLAUDE.md com instruções do scraper
 
 ### Fase 1 — Dados ✅ (base)
 - [ ] Setup Next.js 16 + TypeScript + Tailwind + Prisma
-- [ ] Configurar Vercel Postgres
+- [ ] Configurar Supabase Postgres
 - [ ] Rodar scraper manualmente para popular o banco
 - [ ] Migrations iniciais
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,12 @@ docs: atualiza CLAUDE.md com instruções do scraper
 - Descrever o que foi feito e como testar
 - Vercel cria preview deploy automático por PR
 
+### Issues
+- Issues criadas por agentes de IA devem ser atribuídas a `@gianimpronta` no momento da criação
+- Ao desmembrar uma issue em sub-issues, manter a atribuição em `@gianimpronta` por padrão
+- Não é necessário workflow de auto-assign enquanto esse fluxo continuar estável
+- Se o projeto passar a ter múltiplos responsáveis abrindo issues com frequência, reavaliar essa convenção
+
 ---
 
 ## Fases do MVP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,11 @@ docs: atualiza CLAUDE.md com instruções do scraper
 - Descrever o que foi feito e como testar
 - Vercel cria preview deploy automático por PR
 
+### Antes de push
+- Sempre rodar `format`, `lint`, `test` e `e2e` antes de qualquer `git push`
+- Não fazer push com qualquer uma dessas etapas falhando
+- Ao descrever validação em PRs, incluir de forma objetiva que essas quatro etapas foram executadas
+
 ### Issues
 - Issues criadas por agentes de IA devem ser atribuídas a `@gianimpronta` no momento da criação
 - Ao desmembrar uma issue em sub-issues, manter a atribuição em `@gianimpronta` por padrão

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,17 +27,17 @@ devem ser alterados manualmente no banco.
 
 ## Stack
 
-| Camada | Tecnologia |
-|---|---|
-| Framework | Next.js 16 (App Router) + TypeScript |
-| Estilização | Tailwind CSS |
-| ORM | Prisma |
-| Banco de dados | Supabase Postgres |
-| Autenticação | NextAuth.js v5 (Google OAuth) |
-| Mapa | Leaflet.js |
-| Scraper | Python 3.12 + BeautifulSoup + psycopg2 |
-| CI/CD | GitHub Actions |
-| Hospedagem | Vercel |
+| Camada         | Tecnologia                             |
+| -------------- | -------------------------------------- |
+| Framework      | Next.js 16 (App Router) + TypeScript   |
+| Estilização    | Tailwind CSS                           |
+| ORM            | Prisma                                 |
+| Banco de dados | Supabase Postgres                      |
+| Autenticação   | NextAuth.js v5 (Google OAuth)          |
+| Mapa           | Leaflet.js                             |
+| Scraper        | Python 3.12 + BeautifulSoup + psycopg2 |
+| CI/CD          | GitHub Actions                         |
+| Hospedagem     | Vercel                                 |
 
 ---
 
@@ -158,17 +158,20 @@ O scraper usa apenas `DATABASE_URL`, injetada via GitHub Actions Secret.
 ## Comandos úteis de infraestrutura
 
 ### Vercel
+
 - `vercel link`
 - `vercel env pull .env.local`
 - `vercel pull`
 
 ### Supabase
+
 - `supabase link --project-ref <project-ref>`
 - `supabase db pull`
 - `supabase db push`
 - `supabase secrets set --env-file .env.local`
 
 ### GitHub
+
 - `gh auth status`
 - `gh issue view <numero>`
 - `gh issue create`
@@ -199,6 +202,7 @@ DATABASE_URL=<url> python main.py
 ## Convenções de código
 
 ### Geral
+
 - TypeScript strict mode sempre ativado — sem `any`
 - Funções e variáveis em `camelCase`
 - Componentes React em `PascalCase`
@@ -206,17 +210,20 @@ DATABASE_URL=<url> python main.py
 - Sem comentários óbvios — o código deve ser autodescritivo
 
 ### Next.js
+
 - Preferir Server Components por padrão
 - Client Components (`"use client"`) apenas quando necessário (interatividade, hooks)
 - Dados sempre buscados no servidor via Prisma — nunca expor o client do Prisma no browser
 - Rotas de API apenas para mutações (POST/DELETE de favoritos e visitas)
 
 ### Prisma
+
 - Sempre usar o singleton de `lib/prisma.ts`
 - Nunca usar `prisma.$queryRaw` — usar a API do Prisma
 - Migrations via `prisma migrate dev` em desenvolvimento
 
 ### Tailwind
+
 - Sem CSS customizado — usar apenas classes utilitárias do Tailwind
 - Componentes reutilizáveis extraídos para `components/ui/`
 
@@ -225,12 +232,15 @@ DATABASE_URL=<url> python main.py
 ## Fluxo de desenvolvimento
 
 ### Antes de começar qualquer tarefa
+
 1. Ler este arquivo
 2. Verificar se existe issue ou task relacionada
 3. Criar branch a partir de `main` com nome descritivo: `feat/mapa-leaflet`, `fix/filtro-bairro`
 
 ### Commits
+
 Seguir Conventional Commits:
+
 ```
 feat: adiciona mapa interativo com Leaflet
 fix: corrige filtro por bairro no Rio
@@ -239,16 +249,19 @@ docs: atualiza CLAUDE.md com instruções do scraper
 ```
 
 ### Pull Requests
+
 - PRs pequenos e focados — uma funcionalidade por PR
 - Descrever o que foi feito e como testar
 - Vercel cria preview deploy automático por PR
 
 ### Antes de push
+
 - Sempre rodar `format`, `lint`, `test` e `e2e` antes de qualquer `git push`
 - Não fazer push com qualquer uma dessas etapas falhando
 - Ao descrever validação em PRs, incluir de forma objetiva que essas quatro etapas foram executadas
 
 ### Issues
+
 - Issues criadas por agentes de IA devem ser atribuídas a `@gianimpronta` no momento da criação
 - Ao desmembrar uma issue em sub-issues, manter a atribuição em `@gianimpronta` por padrão
 - Não é necessário workflow de auto-assign enquanto esse fluxo continuar estável
@@ -259,24 +272,28 @@ docs: atualiza CLAUDE.md com instruções do scraper
 ## Fases do MVP
 
 ### Fase 1 — Dados ✅ (base)
+
 - [ ] Setup Next.js 16 + TypeScript + Tailwind + Prisma
 - [ ] Configurar Supabase Postgres
 - [ ] Rodar scraper manualmente para popular o banco
 - [ ] Migrations iniciais
 
 ### Fase 2 — Leitura
+
 - [ ] Listagem de butecos com filtro por cidade e bairro
 - [ ] Busca por nome
 - [ ] Página de detalhe do buteco
 - [ ] Mapa interativo com Leaflet
 
 ### Fase 3 — Usuário
+
 - [ ] Google OAuth via NextAuth
 - [ ] Favoritar buteco
 - [ ] Marcar como visitado
 - [ ] Página "Minha Conta" com favoritos e histórico
 
 ### Fase 4 — Produção
+
 - [ ] SEO básico (metadata, Open Graph, sitemap.xml)
 - [ ] Deploy na Vercel
 - [ ] Configurar GitHub Actions cron do scraper
@@ -299,13 +316,13 @@ Este repositório é **público**. Qualquer pessoa pode ler o código.
 
 ## Arquivos obrigatórios no repositório
 
-| Arquivo | Propósito |
-|---|---|
-| `.gitignore` | Ignorar `.env.local`, `.env`, `node_modules/`, `.next/`, `__pycache__/` |
-| `.env.example` | Documentar todas as variáveis necessárias com valores vazios |
-| `README.md` | Descrição, como rodar localmente, stack e créditos |
-| `LICENSE` | MIT — uso livre com atribuição |
-| `CLAUDE.md` | Este arquivo — guia para agentes de IA e colaboradores |
+| Arquivo        | Propósito                                                               |
+| -------------- | ----------------------------------------------------------------------- |
+| `.gitignore`   | Ignorar `.env.local`, `.env`, `node_modules/`, `.next/`, `__pycache__/` |
+| `.env.example` | Documentar todas as variáveis necessárias com valores vazios            |
+| `README.md`    | Descrição, como rodar localmente, stack e créditos                      |
+| `LICENSE`      | MIT — uso livre com atribuição                                          |
+| `CLAUDE.md`    | Este arquivo — guia para agentes de IA e colaboradores                  |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | Framework      | Next.js 15 (App Router) + TypeScript |
 | Estilização    | Tailwind CSS                         |
 | ORM            | Prisma                               |
-| Banco de dados | Vercel Postgres (Neon)               |
+| Banco de dados | Supabase Postgres                    |
 | Autenticação   | NextAuth.js v5 (Google OAuth)        |
 | Mapa           | Leaflet.js                           |
 | Scraper        | Python 3.12 + BeautifulSoup          |
@@ -47,7 +47,7 @@
 
 - Node.js 20+
 - Python 3.12+
-- Uma instância PostgreSQL (local ou Neon free tier)
+- Uma instância PostgreSQL (local ou Supabase)
 
 ### 1. Clone o repositório
 
@@ -130,6 +130,52 @@ DATABASE_URL=<url> python main.py --skip-scrape --backfill-missing-geocodes
 ## Variáveis de ambiente necessárias
 
 Veja o arquivo [`.env.example`](.env.example) para a lista completa com instruções de onde obter cada valor.
+
+## Comandos úteis de infraestrutura
+
+### Vercel
+
+```bash
+vercel link
+vercel env pull .env.local
+vercel pull
+```
+
+- `vercel link`: vincula o diretório local ao projeto da Vercel
+- `vercel env pull .env.local`: baixa as variáveis do projeto para uso local
+- `vercel pull`: sincroniza variáveis e configurações do projeto em `.vercel/`
+
+### Supabase
+
+```bash
+supabase link --project-ref <project-ref>
+supabase db pull
+supabase db push
+supabase secrets set --env-file .env.local
+```
+
+- `supabase link --project-ref <project-ref>`: vincula o projeto local ao projeto remoto no Supabase
+- `supabase db pull`: puxa o estado remoto do banco para o fluxo local de schema/migrations
+- `supabase db push`: aplica migrations locais no banco remoto vinculado
+- `supabase secrets set --env-file .env.local`: envia segredos para o projeto remoto quando necessário
+
+### GitHub
+
+```bash
+gh auth status
+gh issue view 73
+gh issue create
+gh pr create --draft
+gh pr view --web
+gh run list
+```
+
+- `gh auth status`: confirma a autenticação atual no GitHub CLI
+- `gh issue view <numero>`: consulta uma issue existente
+- `gh issue create`: cria uma nova issue
+- `gh pr create --draft`: abre um pull request em draft
+- `gh pr view --web`: abre o PR atual no navegador
+- `gh run list`: lista execuções recentes de GitHub Actions
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ npm run dev
 
 Acesse [http://localhost:3000](http://localhost:3000).
 
+### 6. Rode os testes end-to-end
+
+```bash
+cd apps/web
+pnpm install
+pnpm exec playwright install chromium
+pnpm test:e2e
+```
+
+Os testes e2e usam fixtures estáveis para os fluxos públicos e não dependem do banco real para a execução local ou em CI.
+
 ---
 
 ## Scraper

--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@
 
 ## Stack
 
-| Camada | Tecnologia |
-|---|---|
-| Framework | Next.js 15 (App Router) + TypeScript |
-| Estilização | Tailwind CSS |
-| ORM | Prisma |
-| Banco de dados | Vercel Postgres (Neon) |
-| Autenticação | NextAuth.js v5 (Google OAuth) |
-| Mapa | Leaflet.js |
-| Scraper | Python 3.12 + BeautifulSoup |
-| CI/CD | GitHub Actions |
-| Hospedagem | Vercel |
+| Camada         | Tecnologia                           |
+| -------------- | ------------------------------------ |
+| Framework      | Next.js 15 (App Router) + TypeScript |
+| Estilização    | Tailwind CSS                         |
+| ORM            | Prisma                               |
+| Banco de dados | Vercel Postgres (Neon)               |
+| Autenticação   | NextAuth.js v5 (Google OAuth)        |
+| Mapa           | Leaflet.js                           |
+| Scraper        | Python 3.12 + BeautifulSoup          |
+| CI/CD          | GitHub Actions                       |
+| Hospedagem     | Vercel                               |
 
 ---
 

--- a/apps/web/app/(public)/butecos/[slug]/page.tsx
+++ b/apps/web/app/(public)/butecos/[slug]/page.tsx
@@ -1,16 +1,14 @@
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { prisma } from "@/lib/prisma";
+import { getButecoBySlug } from "@/lib/public-butecos";
 
 export default async function ButecoPage({
   params,
 }: Readonly<{ params: Promise<{ slug: string }> }>) {
   const { slug } = await params;
 
-  const buteco = await prisma.buteco.findUnique({
-    where: { slug },
-  });
+  const buteco = await getButecoBySlug(slug);
 
   if (!buteco) notFound();
 

--- a/apps/web/app/(public)/butecos/page.tsx
+++ b/apps/web/app/(public)/butecos/page.tsx
@@ -1,49 +1,16 @@
 import Link from "next/link";
 import { Suspense } from "react";
-import {
-  buildButecoWhere,
-  countActiveButecoFilters,
-  normalizeButecoFilters,
-} from "@/lib/buteco-filters";
 import { ButecosFilterForm } from "@/components/butecos/filter-form";
-import { prisma } from "@/lib/prisma";
+import { countActiveButecoFilters, normalizeButecoFilters } from "@/lib/buteco-filters";
+import { getButecosPageData } from "@/lib/public-butecos";
 
 export default async function ButecosPage({
   searchParams,
 }: Readonly<{ searchParams: Promise<{ cidade?: string; bairro?: string; q?: string }> }>) {
   const filters = normalizeButecoFilters(await searchParams);
-
-  const [cidades, bairros, butecos] = await Promise.all([
-    prisma.buteco.findMany({
-      select: { cidade: true },
-      distinct: ["cidade"],
-      orderBy: { cidade: "asc" },
-    }),
-    prisma.buteco.findMany({
-      where: {
-        bairro: { not: null },
-        ...(filters.cidade ? { cidade: filters.cidade } : {}),
-      },
-      select: { bairro: true },
-      distinct: ["bairro"],
-      orderBy: { bairro: "asc" },
-    }),
-    prisma.buteco.findMany({
-      where: buildButecoWhere(filters),
-      orderBy: { nome: "asc" },
-      select: {
-        slug: true,
-        nome: true,
-        cidade: true,
-        bairro: true,
-        petiscoNome: true,
-      },
-    }),
-  ]);
+  const { cidades: cidadeOptions, bairros: bairroOptions, butecos } = await getButecosPageData(filters);
 
   const activeFiltersCount = countActiveButecoFilters(filters);
-  const cidadeOptions = cidades.map(({ cidade }) => cidade);
-  const bairroOptions = bairros.flatMap(({ bairro }) => (bairro ? [bairro] : []));
   const activeFiltersSuffix = activeFiltersCount === 1 ? "" : "s";
   const activeFiltersLabel =
     activeFiltersCount > 0 ? ` com ${activeFiltersCount} filtro${activeFiltersSuffix}` : "";

--- a/apps/web/app/(public)/butecos/page.tsx
+++ b/apps/web/app/(public)/butecos/page.tsx
@@ -8,7 +8,11 @@ export default async function ButecosPage({
   searchParams,
 }: Readonly<{ searchParams: Promise<{ cidade?: string; bairro?: string; q?: string }> }>) {
   const filters = normalizeButecoFilters(await searchParams);
-  const { cidades: cidadeOptions, bairros: bairroOptions, butecos } = await getButecosPageData(filters);
+  const {
+    cidades: cidadeOptions,
+    bairros: bairroOptions,
+    butecos,
+  } = await getButecosPageData(filters);
 
   const activeFiltersCount = countActiveButecoFilters(filters);
   const activeFiltersSuffix = activeFiltersCount === 1 ? "" : "s";

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -1,52 +1,13 @@
 import { MapaButecosShell } from "@/components/mapa/mapa-butecos-shell";
-import { prisma } from "@/lib/prisma";
+import { getHomeData } from "@/lib/public-butecos";
 
 export const dynamic = "force-dynamic";
 
-type ButecoComCoordenada = {
-  slug: string;
-  nome: string;
-  bairro: string | null;
-  lat: number;
-  lng: number;
-};
-
-async function getHomeData(): Promise<{ total: number; butecosComMapa: ButecoComCoordenada[] }> {
-  try {
-    const [total, butecos] = await Promise.all([
-      prisma.buteco.count(),
-      prisma.buteco.findMany({
-        where: {
-          lat: { not: null },
-          lng: { not: null },
-        },
-        orderBy: { nome: "asc" },
-        select: {
-          slug: true,
-          nome: true,
-          bairro: true,
-          lat: true,
-          lng: true,
-        },
-      }),
-    ]);
-
-    const butecosComMapa = butecos.flatMap((buteco) => {
-      if (buteco.lat === null || buteco.lng === null) {
-        return [];
-      }
-
-      return [{ ...buteco, lat: buteco.lat, lng: buteco.lng }];
-    });
-
-    return { total, butecosComMapa };
-  } catch {
-    return { total: 0, butecosComMapa: [] };
-  }
-}
-
 export default async function Home() {
-  const { total, butecosComMapa } = await getHomeData();
+  const { total, butecosComMapa } = await getHomeData().catch(() => ({
+    total: 0,
+    butecosComMapa: [],
+  }));
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-5 sm:gap-8 sm:px-6 sm:py-8 lg:px-8">

--- a/apps/web/components/mapa/mapa-butecos.tsx
+++ b/apps/web/components/mapa/mapa-butecos.tsx
@@ -33,10 +33,12 @@ export function MapaButecos({ butecos }: Readonly<MapaButecosProps>) {
   if (butecos.length === 0) {
     return (
       <div className="flex min-h-[42vh] w-full flex-col items-center justify-center rounded-3xl border border-zinc-200 bg-white px-6 py-12 text-center shadow-sm dark:border-zinc-700 dark:bg-zinc-900 sm:min-h-[48vh]">
-        <p className="text-xl font-bold text-zinc-900 dark:text-zinc-50 sm:text-2xl">Mapa em atualização</p>
+        <p className="text-xl font-bold text-zinc-900 dark:text-zinc-50 sm:text-2xl">
+          Mapa em atualização
+        </p>
         <p className="mt-3 max-w-xl text-sm leading-relaxed text-zinc-600 dark:text-zinc-400 sm:text-base">
-          Ainda não existem botecos com geolocalização disponível. Enquanto isso, você já pode conferir a lista
-          completa dos participantes.
+          Ainda não existem botecos com geolocalização disponível. Enquanto isso, você já pode
+          conferir a lista completa dos participantes.
         </p>
         <Link
           href="/butecos"
@@ -82,7 +84,10 @@ export function MapaButecos({ butecos }: Readonly<MapaButecosProps>) {
                 <div className="space-y-1">
                   <p className="font-semibold">{buteco.nome}</p>
                   <p className="text-sm text-zinc-600">{buteco.bairro ?? "Bairro não informado"}</p>
-                  <Link href={`/butecos/${buteco.slug}`} className="text-sm text-amber-700 hover:underline">
+                  <Link
+                    href={`/butecos/${buteco.slug}`}
+                    className="text-sm text-amber-700 hover:underline"
+                  >
                     Ver detalhes
                   </Link>
                 </div>

--- a/apps/web/components/ui/header.tsx
+++ b/apps/web/components/ui/header.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
-import { auth, signOut } from "@/lib/auth";
+import { isE2EFixtureMode } from "@/lib/public-butecos";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 export default async function Header() {
-  const session = await auth();
+  const session = isE2EFixtureMode() ? null : await import("@/lib/auth").then(({ auth }) => auth());
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 pt-5 sm:px-6 sm:pt-8 lg:px-8">
@@ -36,6 +36,7 @@ export default async function Header() {
                 <form
                   action={async () => {
                     "use server";
+                    const { signOut } = await import("@/lib/auth");
                     await signOut({ redirectTo: "/" });
                   }}
                 >

--- a/apps/web/components/ui/theme-toggle.tsx
+++ b/apps/web/components/ui/theme-toggle.tsx
@@ -2,23 +2,12 @@
 
 import { useState } from "react";
 
-function getInitialThemeState(): boolean | null {
-  if (typeof document === "undefined") {
-    return null;
-  }
-
-  return document.documentElement.classList.contains("dark");
-}
-
 export function ThemeToggle() {
-  const [isDark, setIsDark] = useState<boolean | null>(getInitialThemeState);
+  const [isDark, setIsDark] = useState(false);
 
   function toggle() {
-    if (isDark === null) {
-      return;
-    }
-
-    const next = !isDark;
+    const currentThemeIsDark = document.documentElement.classList.contains("dark");
+    const next = !currentThemeIsDark;
     setIsDark(next);
     document.documentElement.classList.toggle("dark", next);
 
@@ -26,8 +15,6 @@ export function ThemeToggle() {
       localStorage.setItem("theme", next ? "dark" : "light");
     } catch {}
   }
-
-  if (isDark === null) return null;
 
   return (
     <button

--- a/apps/web/e2e/public-flows.spec.ts
+++ b/apps/web/e2e/public-flows.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+
+test("carrega a home pública com os elementos principais", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Descubra os botecos no mapa",
+    })
+  ).toBeVisible();
+  await expect(page.getByText("3 botecos participando")).toBeVisible();
+  await expect(page.locator('section[aria-label="Mapa de botecos"]')).toBeVisible();
+});
+
+test("navega da home para a listagem de botecos", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("link", { name: "Ver botecos" }).click();
+
+  await expect(page).toHaveURL(/\/butecos$/);
+  await expect(page.getByRole("heading", { name: "Botecos" })).toBeVisible();
+});
+
+test("filtra a listagem por cidade", async ({ page }) => {
+  await page.goto("/butecos");
+
+  await page.locator('select[name="cidade"]').selectOption("Belo Horizonte");
+
+  await expect(page).toHaveURL(/cidade=Belo(\+|%20)Horizonte/);
+  await expect(page.getByText("2 resultados com 1 filtro")).toBeVisible();
+  await expect(page.getByRole("link", { name: /Bar do Zeca/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Cantin do João/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Esquina da Célia/i })).toHaveCount(0);
+});
+
+test("filtra a listagem por bairro dentro da cidade selecionada", async ({ page }) => {
+  await page.goto("/butecos");
+
+  await page.locator('select[name="cidade"]').selectOption("Belo Horizonte");
+  await expect(page).toHaveURL(/cidade=Belo(\+|%20)Horizonte/);
+  await page.locator('select[name="bairro"]').selectOption("Savassi");
+  await page.getByRole("button", { name: "Aplicar filtros" }).click();
+
+  await expect(page).toHaveURL(/cidade=Belo(\+|%20)Horizonte/);
+  await expect(page).toHaveURL(/bairro=Savassi/);
+  await expect(page.getByText("1 resultado com 2 filtros")).toBeVisible();
+  await expect(page.getByRole("link", { name: /Bar do Zeca/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Cantin do João/i })).toHaveCount(0);
+});
+
+test("busca por nome do buteco ou petisco", async ({ page }) => {
+  await page.goto("/butecos");
+
+  await page.locator('input[name="q"]').fill("Torresmo");
+  await page.getByRole("button", { name: "Aplicar filtros" }).click();
+
+  await expect(page).toHaveURL(/q=Torresmo/);
+  await expect(page.getByText("1 resultado com 1 filtro")).toBeVisible();
+  await expect(page.getByRole("link", { name: /Cantin do João/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Bar do Zeca/i })).toHaveCount(0);
+});
+
+test("exibe estado vazio quando não há resultados", async ({ page }) => {
+  await page.goto("/butecos");
+
+  await page.locator('input[name="q"]').fill("Inexistente");
+  await page.getByRole("button", { name: "Aplicar filtros" }).click();
+
+  await expect(page).toHaveURL(/q=Inexistente/);
+  await expect(page.getByRole("heading", { name: "Nenhum boteco encontrado" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Limpar filtros" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Voltar para a home" })).toBeVisible();
+});
+
+test("navega da listagem para a página de detalhe", async ({ page }) => {
+  await page.goto("/butecos");
+
+  await page.getByRole("link", { name: /Bar do Zeca/i }).click();
+
+  await expect(page).toHaveURL(/\/butecos\/bar-do-zeca$/);
+  await expect(page.getByRole("heading", { name: "Bar do Zeca" })).toBeVisible();
+});
+
+test("renderiza os dados principais da página de detalhe", async ({ page }) => {
+  await page.goto("/butecos/bar-do-zeca");
+
+  await expect(page.getByRole("heading", { name: "Bar do Zeca" })).toBeVisible();
+  await expect(page.getByText("Savassi, Belo Horizonte", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Bolinho da Casa" })).toBeVisible();
+  await expect(page.getByText("Rua dos Testes, 123 - Savassi, Belo Horizonte - MG")).toBeVisible();
+  await expect(page.getByText("(31) 3333-1111")).toBeVisible();
+});

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -11,6 +11,8 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "playwright-report/**",
+    "test-results/**",
     "next-env.d.ts",
   ]),
 ]);

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
   coverageProvider: "v8",
   testEnvironment: "node",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  testPathIgnorePatterns: ["<rootDir>/e2e/"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -11,12 +11,7 @@ const config: Config = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },
-  collectCoverageFrom: [
-    "app/api/**/*.ts",
-    "lib/**/*.ts",
-    "!lib/**/__tests__/**",
-    "!**/*.d.ts",
-  ],
+  collectCoverageFrom: ["app/api/**/*.ts", "lib/**/*.ts", "!lib/**/__tests__/**", "!**/*.d.ts"],
 };
 
 export default createJestConfig(config);

--- a/apps/web/lib/__tests__/public-butecos.test.ts
+++ b/apps/web/lib/__tests__/public-butecos.test.ts
@@ -1,0 +1,85 @@
+import {
+  getButecoBySlug,
+  getButecosPageData,
+  getHomeData,
+  isE2EFixtureMode,
+} from "@/lib/public-butecos";
+
+describe("public-butecos fixtures", () => {
+  const originalEnv = process.env.E2E_USE_FIXTURES;
+
+  beforeEach(() => {
+    process.env.E2E_USE_FIXTURES = "true";
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.E2E_USE_FIXTURES;
+      return;
+    }
+
+    process.env.E2E_USE_FIXTURES = originalEnv;
+  });
+
+  it("detects fixture mode from environment", () => {
+    expect(isE2EFixtureMode()).toBe(true);
+  });
+
+  it("returns summary data for the home page", async () => {
+    const data = await getHomeData();
+
+    expect(data.total).toBe(3);
+    expect(data.butecosComMapa).toHaveLength(3);
+    expect(data.butecosComMapa[0]).toEqual({
+      slug: "bar-do-zeca",
+      nome: "Bar do Zeca",
+      bairro: "Savassi",
+      lat: -19.9385,
+      lng: -43.9342,
+    });
+  });
+
+  it("filters butecos by city and neighborhood", async () => {
+    const data = await getButecosPageData({
+      cidade: "Belo Horizonte",
+      bairro: "Savassi",
+    });
+
+    expect(data.cidades).toEqual(["Belo Horizonte", "Contagem"]);
+    expect(data.bairros).toEqual(["Centro", "Savassi"]);
+    expect(data.butecos).toEqual([
+      {
+        slug: "bar-do-zeca",
+        nome: "Bar do Zeca",
+        cidade: "Belo Horizonte",
+        bairro: "Savassi",
+        petiscoNome: "Bolinho da Casa",
+      },
+    ]);
+  });
+
+  it("filters butecos by search term in buteco name or snack name", async () => {
+    const byPetisco = await getButecosPageData({ q: "Torresmo" });
+    const byButeco = await getButecosPageData({ q: "Célia" });
+
+    expect(byPetisco.butecos.map(({ slug }) => slug)).toEqual(["cantin-do-joao"]);
+    expect(byButeco.butecos.map(({ slug }) => slug)).toEqual(["esquina-da-celia"]);
+  });
+
+  it("returns detailed data for a known slug and null for an unknown one", async () => {
+    await expect(getButecoBySlug("bar-do-zeca")).resolves.toEqual({
+      slug: "bar-do-zeca",
+      nome: "Bar do Zeca",
+      cidade: "Belo Horizonte",
+      bairro: "Savassi",
+      endereco: "Rua dos Testes, 123 - Savassi, Belo Horizonte - MG",
+      telefone: "(31) 3333-1111",
+      horario: "Seg a Sáb, 18h às 23h",
+      petiscoNome: "Bolinho da Casa",
+      petiscoDesc: "Bolinho crocante de carne com molho da casa.",
+      fotoUrl: null,
+    });
+
+    await expect(getButecoBySlug("inexistente")).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/__tests__/public-butecos.test.ts
+++ b/apps/web/lib/__tests__/public-butecos.test.ts
@@ -1,3 +1,13 @@
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    buteco: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
 import {
   getButecoBySlug,
   getButecosPageData,
@@ -5,11 +15,22 @@ import {
   isE2EFixtureMode,
 } from "@/lib/public-butecos";
 
+const { prisma } = jest.requireMock("@/lib/prisma") as {
+  prisma: {
+    buteco: {
+      count: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+    };
+  };
+};
+
 describe("public-butecos fixtures", () => {
   const originalEnv = process.env.E2E_USE_FIXTURES;
 
   beforeEach(() => {
     process.env.E2E_USE_FIXTURES = "true";
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
@@ -81,5 +102,93 @@ describe("public-butecos fixtures", () => {
     });
 
     await expect(getButecoBySlug("inexistente")).resolves.toBeNull();
+  });
+});
+
+describe("public-butecos prisma mode", () => {
+  const originalEnv = process.env.E2E_USE_FIXTURES;
+
+  beforeEach(() => {
+    delete process.env.E2E_USE_FIXTURES;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.E2E_USE_FIXTURES;
+      return;
+    }
+
+    process.env.E2E_USE_FIXTURES = originalEnv;
+  });
+
+  it("returns home data from prisma when fixture mode is disabled", async () => {
+    prisma.buteco.count.mockResolvedValue(4);
+    prisma.buteco.findMany.mockResolvedValue([
+      { slug: "zeca", nome: "Zeca", bairro: "Centro", lat: -1, lng: -2 },
+      { slug: "sem-mapa", nome: "Sem mapa", bairro: null, lat: null, lng: null },
+    ]);
+
+    await expect(getHomeData()).resolves.toEqual({
+      total: 4,
+      butecosComMapa: [{ slug: "zeca", nome: "Zeca", bairro: "Centro", lat: -1, lng: -2 }],
+    });
+  });
+
+  it("returns list data from prisma when fixture mode is disabled", async () => {
+    prisma.buteco.findMany
+      .mockResolvedValueOnce([{ cidade: "Belo Horizonte" }, { cidade: "Contagem" }])
+      .mockResolvedValueOnce([{ bairro: "Savassi" }, { bairro: null }])
+      .mockResolvedValueOnce([
+        {
+          slug: "bar-do-zeca",
+          nome: "Bar do Zeca",
+          cidade: "Belo Horizonte",
+          bairro: "Savassi",
+          petiscoNome: "Bolinho da Casa",
+        },
+      ]);
+
+    await expect(getButecosPageData({ cidade: "Belo Horizonte" })).resolves.toEqual({
+      cidades: ["Belo Horizonte", "Contagem"],
+      bairros: ["Savassi"],
+      butecos: [
+        {
+          slug: "bar-do-zeca",
+          nome: "Bar do Zeca",
+          cidade: "Belo Horizonte",
+          bairro: "Savassi",
+          petiscoNome: "Bolinho da Casa",
+        },
+      ],
+    });
+  });
+
+  it("returns detail data from prisma when fixture mode is disabled", async () => {
+    prisma.buteco.findUnique.mockResolvedValue({
+      slug: "bar-do-zeca",
+      nome: "Bar do Zeca",
+      cidade: "Belo Horizonte",
+      bairro: "Savassi",
+      endereco: "Rua dos Testes, 123 - Savassi, Belo Horizonte - MG",
+      telefone: "(31) 3333-1111",
+      horario: "Seg a Sáb, 18h às 23h",
+      petiscoNome: "Bolinho da Casa",
+      petiscoDesc: "Bolinho crocante de carne com molho da casa.",
+      fotoUrl: null,
+    });
+
+    await expect(getButecoBySlug("bar-do-zeca")).resolves.toEqual({
+      slug: "bar-do-zeca",
+      nome: "Bar do Zeca",
+      cidade: "Belo Horizonte",
+      bairro: "Savassi",
+      endereco: "Rua dos Testes, 123 - Savassi, Belo Horizonte - MG",
+      telefone: "(31) 3333-1111",
+      horario: "Seg a Sáb, 18h às 23h",
+      petiscoNome: "Bolinho da Casa",
+      petiscoDesc: "Bolinho crocante de carne com molho da casa.",
+      fotoUrl: null,
+    });
   });
 });

--- a/apps/web/lib/public-butecos.ts
+++ b/apps/web/lib/public-butecos.ts
@@ -108,20 +108,16 @@ function filterFixtureButecos(filters: ButecoSearchFilters): PublicButecoRecord[
       return true;
     }
 
-    return where.OR.some((condition) => {
-      const containsValue =
-        "nome" in condition ? condition.nome?.contains : condition.petiscoNome?.contains;
+    const query = normalizedFilters.q?.toLocaleLowerCase("pt-BR");
 
-      if (!containsValue) {
-        return false;
-      }
+    if (!query) {
+      return true;
+    }
 
-      const query = containsValue.toLocaleLowerCase("pt-BR");
-      return (
-        buteco.nome.toLocaleLowerCase("pt-BR").includes(query) ||
-        buteco.petiscoNome?.toLocaleLowerCase("pt-BR").includes(query) === true
-      );
-    });
+    return (
+      buteco.nome.toLocaleLowerCase("pt-BR").includes(query) ||
+      buteco.petiscoNome?.toLocaleLowerCase("pt-BR").includes(query) === true
+    );
   });
 }
 

--- a/apps/web/lib/public-butecos.ts
+++ b/apps/web/lib/public-butecos.ts
@@ -109,7 +109,8 @@ function filterFixtureButecos(filters: ButecoSearchFilters): PublicButecoRecord[
     }
 
     return where.OR.some((condition) => {
-      const containsValue = "nome" in condition ? condition.nome?.contains : condition.petiscoNome?.contains;
+      const containsValue =
+        "nome" in condition ? condition.nome?.contains : condition.petiscoNome?.contains;
 
       if (!containsValue) {
         return false;
@@ -182,13 +183,15 @@ export async function getButecosPageData(filters: ButecoSearchFilters) {
   if (isE2EFixtureMode()) {
     const normalizedFilters = normalizeButecoFilters(filters);
     const filteredButecos = filterFixtureButecos(normalizedFilters);
-    const cidades = [...new Set(e2eFixtureButecos.map((buteco) => buteco.cidade))].sort((left, right) =>
-      left.localeCompare(right, "pt-BR")
+    const cidades = [...new Set(e2eFixtureButecos.map((buteco) => buteco.cidade))].sort(
+      (left, right) => left.localeCompare(right, "pt-BR")
     );
     const bairros = [
       ...new Set(
         e2eFixtureButecos
-          .filter((buteco) => !normalizedFilters.cidade || buteco.cidade === normalizedFilters.cidade)
+          .filter(
+            (buteco) => !normalizedFilters.cidade || buteco.cidade === normalizedFilters.cidade
+          )
           .flatMap((buteco) => (buteco.bairro ? [buteco.bairro] : []))
       ),
     ].sort((left, right) => left.localeCompare(right, "pt-BR"));

--- a/apps/web/lib/public-butecos.ts
+++ b/apps/web/lib/public-butecos.ts
@@ -1,0 +1,276 @@
+import {
+  buildButecoWhere,
+  normalizeButecoFilters,
+  type ButecoSearchFilters,
+} from "@/lib/buteco-filters";
+
+export type PublicButecoListItem = {
+  slug: string;
+  nome: string;
+  cidade: string;
+  bairro: string | null;
+  petiscoNome: string | null;
+};
+
+export type PublicButecoMapItem = {
+  slug: string;
+  nome: string;
+  bairro: string | null;
+  lat: number;
+  lng: number;
+};
+
+export type PublicButecoDetail = {
+  slug: string;
+  nome: string;
+  cidade: string;
+  bairro: string | null;
+  endereco: string;
+  telefone: string | null;
+  horario: string | null;
+  petiscoNome: string | null;
+  petiscoDesc: string | null;
+  fotoUrl: string | null;
+};
+
+type PublicButecoRecord = PublicButecoDetail & {
+  lat: number | null;
+  lng: number | null;
+};
+
+const e2eFixtureButecos: PublicButecoRecord[] = [
+  {
+    slug: "bar-do-zeca",
+    nome: "Bar do Zeca",
+    cidade: "Belo Horizonte",
+    bairro: "Savassi",
+    endereco: "Rua dos Testes, 123 - Savassi, Belo Horizonte - MG",
+    telefone: "(31) 3333-1111",
+    horario: "Seg a Sáb, 18h às 23h",
+    petiscoNome: "Bolinho da Casa",
+    petiscoDesc: "Bolinho crocante de carne com molho da casa.",
+    fotoUrl: null,
+    lat: -19.9385,
+    lng: -43.9342,
+  },
+  {
+    slug: "cantin-do-joao",
+    nome: "Cantin do João",
+    cidade: "Belo Horizonte",
+    bairro: "Centro",
+    endereco: "Av. Brasil, 456 - Centro, Belo Horizonte - MG",
+    telefone: "(31) 3333-2222",
+    horario: "Ter a Dom, 17h às 23h",
+    petiscoNome: "Torresmo Mineiro",
+    petiscoDesc: "Torresmo pururuca com limão e mandioca.",
+    fotoUrl: null,
+    lat: -19.9191,
+    lng: -43.9386,
+  },
+  {
+    slug: "esquina-da-celia",
+    nome: "Esquina da Célia",
+    cidade: "Contagem",
+    bairro: "Eldorado",
+    endereco: "Rua Principal, 789 - Eldorado, Contagem - MG",
+    telefone: "(31) 3333-3333",
+    horario: "Qua a Dom, 18h às 22h",
+    petiscoNome: "Trem Bão",
+    petiscoDesc: "Linguiça artesanal com mandioca cremosa.",
+    fotoUrl: null,
+    lat: -19.9321,
+    lng: -44.0534,
+  },
+];
+
+export function isE2EFixtureMode(): boolean {
+  return process.env.E2E_USE_FIXTURES === "true";
+}
+
+function sortByName<T extends { nome: string }>(items: T[]): T[] {
+  return [...items].sort((left, right) => left.nome.localeCompare(right.nome, "pt-BR"));
+}
+
+function filterFixtureButecos(filters: ButecoSearchFilters): PublicButecoRecord[] {
+  const normalizedFilters = normalizeButecoFilters(filters);
+  const where = buildButecoWhere(normalizedFilters);
+
+  return sortByName(e2eFixtureButecos).filter((buteco) => {
+    if (where.cidade && buteco.cidade !== where.cidade) {
+      return false;
+    }
+
+    if (where.bairro && buteco.bairro !== where.bairro) {
+      return false;
+    }
+
+    if (!where.OR) {
+      return true;
+    }
+
+    return where.OR.some((condition) => {
+      const containsValue = "nome" in condition ? condition.nome?.contains : condition.petiscoNome?.contains;
+
+      if (!containsValue) {
+        return false;
+      }
+
+      const query = containsValue.toLocaleLowerCase("pt-BR");
+      return (
+        buteco.nome.toLocaleLowerCase("pt-BR").includes(query) ||
+        buteco.petiscoNome?.toLocaleLowerCase("pt-BR").includes(query) === true
+      );
+    });
+  });
+}
+
+export async function getHomeData() {
+  if (isE2EFixtureMode()) {
+    const butecosComMapa = sortByName(e2eFixtureButecos).flatMap((buteco) => {
+      if (buteco.lat === null || buteco.lng === null) {
+        return [];
+      }
+
+      return [
+        {
+          slug: buteco.slug,
+          nome: buteco.nome,
+          bairro: buteco.bairro,
+          lat: buteco.lat,
+          lng: buteco.lng,
+        } satisfies PublicButecoMapItem,
+      ];
+    });
+
+    return {
+      total: e2eFixtureButecos.length,
+      butecosComMapa,
+    };
+  }
+
+  const { prisma } = await import("@/lib/prisma");
+  const [total, butecos] = await Promise.all([
+    prisma.buteco.count(),
+    prisma.buteco.findMany({
+      where: {
+        lat: { not: null },
+        lng: { not: null },
+      },
+      orderBy: { nome: "asc" },
+      select: {
+        slug: true,
+        nome: true,
+        bairro: true,
+        lat: true,
+        lng: true,
+      },
+    }),
+  ]);
+
+  const butecosComMapa = butecos.flatMap((buteco) => {
+    if (buteco.lat === null || buteco.lng === null) {
+      return [];
+    }
+
+    return [{ ...buteco, lat: buteco.lat, lng: buteco.lng }];
+  });
+
+  return { total, butecosComMapa };
+}
+
+export async function getButecosPageData(filters: ButecoSearchFilters) {
+  if (isE2EFixtureMode()) {
+    const normalizedFilters = normalizeButecoFilters(filters);
+    const filteredButecos = filterFixtureButecos(normalizedFilters);
+    const cidades = [...new Set(e2eFixtureButecos.map((buteco) => buteco.cidade))].sort((left, right) =>
+      left.localeCompare(right, "pt-BR")
+    );
+    const bairros = [
+      ...new Set(
+        e2eFixtureButecos
+          .filter((buteco) => !normalizedFilters.cidade || buteco.cidade === normalizedFilters.cidade)
+          .flatMap((buteco) => (buteco.bairro ? [buteco.bairro] : []))
+      ),
+    ].sort((left, right) => left.localeCompare(right, "pt-BR"));
+
+    return {
+      cidades,
+      bairros,
+      butecos: filteredButecos.map(
+        ({ slug, nome, cidade, bairro, petiscoNome }) =>
+          ({
+            slug,
+            nome,
+            cidade,
+            bairro,
+            petiscoNome,
+          }) satisfies PublicButecoListItem
+      ),
+    };
+  }
+
+  const { prisma } = await import("@/lib/prisma");
+  const normalizedFilters = normalizeButecoFilters(filters);
+
+  const [cidades, bairros, butecos] = await Promise.all([
+    prisma.buteco.findMany({
+      select: { cidade: true },
+      distinct: ["cidade"],
+      orderBy: { cidade: "asc" },
+    }),
+    prisma.buteco.findMany({
+      where: {
+        bairro: { not: null },
+        ...(normalizedFilters.cidade ? { cidade: normalizedFilters.cidade } : {}),
+      },
+      select: { bairro: true },
+      distinct: ["bairro"],
+      orderBy: { bairro: "asc" },
+    }),
+    prisma.buteco.findMany({
+      where: buildButecoWhere(normalizedFilters),
+      orderBy: { nome: "asc" },
+      select: {
+        slug: true,
+        nome: true,
+        cidade: true,
+        bairro: true,
+        petiscoNome: true,
+      },
+    }),
+  ]);
+
+  return {
+    cidades: cidades.map(({ cidade }) => cidade),
+    bairros: bairros.flatMap(({ bairro }) => (bairro ? [bairro] : [])),
+    butecos,
+  };
+}
+
+export async function getButecoBySlug(slug: string): Promise<PublicButecoDetail | null> {
+  if (isE2EFixtureMode()) {
+    const buteco = e2eFixtureButecos.find((item) => item.slug === slug);
+
+    if (!buteco) {
+      return null;
+    }
+
+    return {
+      slug: buteco.slug,
+      nome: buteco.nome,
+      cidade: buteco.cidade,
+      bairro: buteco.bairro,
+      endereco: buteco.endereco,
+      telefone: buteco.telefone,
+      horario: buteco.horario,
+      petiscoNome: buteco.petiscoNome,
+      petiscoDesc: buteco.petiscoDesc,
+      fotoUrl: buteco.fotoUrl,
+    };
+  }
+
+  const { prisma } = await import("@/lib/prisma");
+  return prisma.buteco.findUnique({
+    where: { slug },
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,8 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "jest",
-    "test:e2e": "playwright test",
-    "format:check": "prettier --check \"app/**/*.{ts,tsx}\" \"lib/**/*.{ts,tsx}\""
+    "test:e2e": "prisma generate && playwright test",
+    "format:check": "prettier --check \"app/**/*.{ts,tsx}\" \"lib/**/*.{ts,tsx}\"",
+    "test:e2e:setup": "prisma generate && playwright install --with-deps chromium"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.7.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "test": "jest",
+    "test:e2e": "playwright test",
     "format:check": "prettier --check \"app/**/*.{ts,tsx}\" \"lib/**/*.{ts,tsx}\""
   },
   "dependencies": {
@@ -26,6 +27,7 @@
     "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = 3000;
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "pnpm exec next dev --hostname 127.0.0.1 --port 3000",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    env: {
+      E2E_USE_FIXTURES: "true",
+      GOOGLE_CLIENT_ID: "e2e-google-client-id",
+      GOOGLE_CLIENT_SECRET: "e2e-google-client-secret",
+      NEXTAUTH_SECRET: "e2e-secret-with-at-least-32-characters",
+      NEXTAUTH_URL: baseURL,
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+});

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -20,10 +20,10 @@ importers:
         version: 7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.0.1(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.0.0(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -32,10 +32,10 @@ importers:
         version: 1.9.4
       next:
         specifier: 16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-auth:
         specifier: ^5.0.0-beta.31
-        version: 5.0.0-beta.31(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 5.0.0-beta.31(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -52,6 +52,9 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(leaflet@1.9.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.3
@@ -450,89 +453,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -709,24 +728,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.4':
     resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.4':
     resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.4':
     resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.4':
     resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
@@ -766,6 +789,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/adapter-pg@7.7.0':
     resolution: {integrity: sha512-q33Ta8sKbgzEpAy0lx45tAq//yMv0qcb+8nj+TCA3P4wiAY+OBFEFk/NDkZncAfHaNJeGo5WJpJdpbL+ijYx8g==}
@@ -967,24 +995,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.3':
     resolution: {integrity: sha512-MmIA32rNEOrjh6wnevlR3OjjlCuwgZ4JMJo7Vrhk4Fk56Vxi7EeF7cekSKwvlrnfcn/ERC1LdcG3sFneU8WdoA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.3':
     resolution: {integrity: sha512-BiCy1YV0IKO+xbD7gyZnENU4jdwDygeGQjncJoeIE5Kp4UqWHFsKUSJ3pp7vYURrqVzwJX2xD5gQeGnoXp4xPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.3':
     resolution: {integrity: sha512-venvyAu0AMKdr0c1Oz23IJJdZ72zSwKyHrLvqQV1cn49vPAJk3AuVtDkJ1ayk1sYI4M4j8Jv6ZGflpaP0QVSXQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.3':
     resolution: {integrity: sha512-e3kColrZZCdtbwIOc07cNQ2zNf1sTPXTYLjjPlsgsaf+ttzAg/hOlDyEgHoOlBGxM88nPxeVaOGe9ThqVzPncg==}
@@ -1227,41 +1259,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2050,6 +2090,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2665,24 +2710,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3046,6 +3095,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4427,6 +4486,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@prisma/adapter-pg@7.7.0':
     dependencies:
       '@prisma/driver-adapter-utils': 7.7.0
@@ -4954,14 +5017,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@2.0.1(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@vercel/analytics@2.0.1(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
-      next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  '@vercel/speed-insights@2.0.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@vercel/speed-insights@2.0.0(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
-      next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -5832,6 +5895,9 @@ snapshots:
       signal-exit: 4.1.0
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -6765,13 +6831,13 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-auth@5.0.0-beta.31(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  next-auth@5.0.0-beta.31(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       '@auth/core': 0.41.2
-      next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -6790,6 +6856,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.4
       '@next/swc-win32-arm64-msvc': 16.2.4
       '@next/swc-win32-x64-msvc': 16.2.4
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6995,6 +7062,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/apps/web/test-results/.last-run.json
+++ b/apps/web/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/docs/superpowers/plans/2026-04-22-issue-73-subissues-kickoff.md
+++ b/docs/superpowers/plans/2026-04-22-issue-73-subissues-kickoff.md
@@ -1,0 +1,35 @@
+# Kickoff das sub-issues da #73 (E2E)
+
+Data: 2026-04-22  
+Issue pai: #73 — `feat: criar testes end-to-end para os fluxos principais da aplicação`
+
+## O que foi iniciado de forma prática
+
+- Foi adicionado o script `scripts/start-issue-73-subissue-branches.sh` para criar, de forma idempotente, as branches de cada sub-issue da #73.
+- O script aceita um `base_ref` opcional (padrão: `HEAD`) para decidir o ponto de criação das branches.
+- As branches da #74 até #81 são criadas automaticamente com os nomes combinados para o fluxo E2E.
+
+## Como executar
+
+```bash
+./scripts/start-issue-73-subissue-branches.sh
+```
+
+Ou informando explicitamente uma base (ex.: `main`):
+
+```bash
+./scripts/start-issue-73-subissue-branches.sh main
+```
+
+## Mapeamento oficial
+
+| Sub-issue | Branch |
+|---|---|
+| #74 | `test/e2e-home-carregamento` |
+| #75 | `test/e2e-home-listagem-navegacao` |
+| #76 | `test/e2e-listagem-filtro-cidade` |
+| #77 | `test/e2e-listagem-filtro-bairro` |
+| #78 | `test/e2e-listagem-busca-nome` |
+| #79 | `test/e2e-listagem-sem-resultados` |
+| #80 | `test/e2e-listagem-detalhe-navegacao` |
+| #81 | `test/e2e-detalhe-renderizacao` |

--- a/docs/superpowers/reports/2026-04-22-issue-73-subissues-status.md
+++ b/docs/superpowers/reports/2026-04-22-issue-73-subissues-status.md
@@ -1,0 +1,35 @@
+# Status de execução das sub-issues da #73 (E2E)
+
+Data: 2026-04-22
+
+## Escopo
+Sub-issues: #74, #75, #76, #77, #78, #79, #80, #81.
+
+## Branches verificadas
+
+Todas as branches abaixo apontam para o mesmo commit base (`a56a21e1b756cbfb75a01ea5a772f57e4d88deca`), então a validação dos comandos foi feita uma vez e aplicada para todas:
+
+- `test/e2e-home-carregamento`
+- `test/e2e-home-listagem-navegacao`
+- `test/e2e-listagem-filtro-cidade`
+- `test/e2e-listagem-filtro-bairro`
+- `test/e2e-listagem-busca-nome`
+- `test/e2e-listagem-sem-resultados`
+- `test/e2e-listagem-detalhe-navegacao`
+- `test/e2e-detalhe-renderizacao`
+
+## Qualidade executada
+
+1. `pnpm lint`
+2. `pnpm format:check`
+3. `pnpm test`
+4. `pnpm test:e2e`
+
+## Ajuste aplicado para estabilidade do fluxo E2E
+
+Foi atualizado o `apps/web/package.json` para:
+
+- incluir `test:e2e:setup` com geração do Prisma Client e instalação de dependências do Playwright (`--with-deps`);
+- sempre rodar `prisma generate` antes do `playwright test` em `test:e2e`.
+
+Com isso, o fluxo de validação por branch fica reprodutível antes da abertura de MR.

--- a/scripts/start-issue-73-subissue-branches.sh
+++ b/scripts/start-issue-73-subissue-branches.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${1:-HEAD}"
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  echo "Base ref inválida: $base_ref" >&2
+  echo "Uso: $0 [base_ref]" >&2
+  exit 1
+fi
+
+subissues=(
+  "74:test/e2e-home-carregamento"
+  "75:test/e2e-home-listagem-navegacao"
+  "76:test/e2e-listagem-filtro-cidade"
+  "77:test/e2e-listagem-filtro-bairro"
+  "78:test/e2e-listagem-busca-nome"
+  "79:test/e2e-listagem-sem-resultados"
+  "80:test/e2e-listagem-detalhe-navegacao"
+  "81:test/e2e-detalhe-renderizacao"
+)
+
+echo "Criando branches das sub-issues da #73 a partir de: $base_ref"
+
+for entry in "${subissues[@]}"; do
+  issue_number="${entry%%:*}"
+  branch_name="${entry#*:}"
+
+  if git show-ref --verify --quiet "refs/heads/$branch_name"; then
+    echo "- #$issue_number -> $branch_name (já existe)"
+    continue
+  fi
+
+  git branch "$branch_name" "$base_ref"
+  echo "- #$issue_number -> $branch_name (criada)"
+done
+
+echo
+echo "Resumo:"
+git branch --list 'test/e2e-*' | sed 's/^/  /'


### PR DESCRIPTION
## Summary
- Adds Playwright e2e coverage for the public app flows: home, list, filters, search, empty state, and detail navigation
- Introduces deterministic e2e fixtures and routes public pages through them when `E2E_USE_FIXTURES=true`
- Updates CI to run the e2e suite and documents the local command in the README

## Testing
- `pnpm test`
- `pnpm test:e2e`