### PR TITLE
fix: ignore Playwright e2e specs in Jest discovery

### DIFF
--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   coverageProvider: "v8",
   testEnvironment: "node",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
-  testPathIgnorePatterns: ["<rootDir>/e2e/"],
+  testPathIgnorePatterns: [String.raw`[/\\]e2e[/\\]`],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },


### PR DESCRIPTION
## Summary
- make the Jest ignore rule for e2e/ work consistently on Windows and Unix-like paths
- keep pnpm test scoped to the unit/integration suites while preserving pnpm test:e2e
- align local verification with the e2e infrastructure delivered in #82

## Testing
- pnpm lint
- pnpm test
- pnpm test:e2e

Refs #73