### PR TITLE
feat: adiciona SEO básico público

### DIFF
--- a/apps/web/app/(public)/butecos/[slug]/page.tsx
+++ b/apps/web/app/(public)/butecos/[slug]/page.tsx
@@ -1,7 +1,52 @@
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getButecoBySlug } from "@/lib/public-butecos";
+
+export async function generateMetadata({
+  params,
+}: Readonly<{ params: Promise<{ slug: string }> }>): Promise<Metadata> {
+  const { slug } = await params;
+  const buteco = await getButecoBySlug(slug);
+
+  if (!buteco) {
+    return {
+      title: "Buteco não encontrado",
+      description: "O buteco procurado não foi encontrado.",
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
+  const description = buteco.petiscoNome
+    ? `${buteco.petiscoNome} no ${buteco.nome}, em ${buteco.bairro ? `${buteco.bairro}, ` : ""}${buteco.cidade}.`
+    : `${buteco.nome} em ${buteco.bairro ? `${buteco.bairro}, ` : ""}${buteco.cidade}.`;
+  const url = `/butecos/${buteco.slug}`;
+
+  return {
+    title: buteco.nome,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title: buteco.nome,
+      description,
+      url,
+      type: "article",
+      images: buteco.fotoUrl ? [{ url: buteco.fotoUrl, alt: buteco.nome }] : undefined,
+    },
+    twitter: {
+      title: buteco.nome,
+      description,
+      card: buteco.fotoUrl ? "summary_large_image" : "summary",
+      images: buteco.fotoUrl ? [buteco.fotoUrl] : undefined,
+    },
+  };
+}
 
 export default async function ButecoPage({
   params,

--- a/apps/web/app/__tests__/seo-metadata.test.ts
+++ b/apps/web/app/__tests__/seo-metadata.test.ts
@@ -1,0 +1,132 @@
+jest.mock("next/font/google", () => ({
+  Geist: () => ({ variable: "--font-geist-sans" }),
+  Geist_Mono: () => ({ variable: "--font-geist-mono" }),
+}));
+
+jest.mock("@vercel/analytics/next", () => ({
+  Analytics: () => null,
+}));
+
+jest.mock("@vercel/speed-insights/next", () => ({
+  SpeedInsights: () => null,
+}));
+
+jest.mock("@/lib/public-butecos", () => ({
+  getButecoBySlug: jest.fn(),
+}));
+
+describe("SEO metadata", () => {
+  const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.NEXTAUTH_URL = "https://www.ondetembuteco.com.br";
+  });
+
+  afterEach(() => {
+    if (originalNextAuthUrl === undefined) {
+      delete process.env.NEXTAUTH_URL;
+      return;
+    }
+
+    process.env.NEXTAUTH_URL = originalNextAuthUrl;
+  });
+
+  it("configures global metadata with canonical and social defaults", async () => {
+    const layoutModule = await import("@/app/layout");
+
+    expect(layoutModule.metadata).toMatchObject({
+      title: {
+        default: "Onde Tem Buteco",
+        template: "%s | Onde Tem Buteco",
+      },
+      description: expect.stringContaining("Comida di Buteco"),
+      alternates: {
+        canonical: "/",
+      },
+      openGraph: expect.objectContaining({
+        title: "Onde Tem Buteco",
+        url: "/",
+        siteName: "Onde Tem Buteco",
+        locale: "pt_BR",
+        type: "website",
+      }),
+      twitter: expect.objectContaining({
+        card: "summary",
+        title: "Onde Tem Buteco",
+      }),
+    });
+
+    expect(layoutModule.metadata.metadataBase?.toString()).toBe(
+      "https://www.ondetembuteco.com.br/"
+    );
+  });
+
+  it("generates detail metadata from the current buteco", async () => {
+    const { getButecoBySlug } = jest.requireMock("@/lib/public-butecos") as {
+      getButecoBySlug: jest.Mock;
+    };
+
+    getButecoBySlug.mockResolvedValue({
+      slug: "bar-do-zeca",
+      nome: "Bar do Zeca",
+      cidade: "Belo Horizonte",
+      bairro: "Savassi",
+      endereco: "Rua dos Testes, 123 - Savassi, Belo Horizonte - MG",
+      telefone: "(31) 3333-1111",
+      horario: "Seg a Sab, 18h as 23h",
+      petiscoNome: "Bolinho da Casa",
+      petiscoDesc: "Bolinho crocante de carne com molho da casa.",
+      fotoUrl: null,
+    });
+
+    const detailPageModule = (await import("@/app/(public)/butecos/[slug]/page")) as {
+      generateMetadata?: (input: { params: Promise<{ slug: string }> }) => Promise<unknown>;
+    };
+
+    expect(detailPageModule.generateMetadata).toEqual(expect.any(Function));
+
+    const metadata = await detailPageModule.generateMetadata?.({
+      params: Promise.resolve({ slug: "bar-do-zeca" }),
+    });
+
+    expect(metadata).toMatchObject({
+      title: "Bar do Zeca",
+      description: expect.stringContaining("Bolinho da Casa"),
+      alternates: {
+        canonical: "/butecos/bar-do-zeca",
+      },
+      openGraph: expect.objectContaining({
+        title: "Bar do Zeca",
+        url: "/butecos/bar-do-zeca",
+      }),
+      twitter: expect.objectContaining({
+        title: "Bar do Zeca",
+      }),
+    });
+  });
+
+  it("marks missing buteco pages as non-indexable", async () => {
+    const { getButecoBySlug } = jest.requireMock("@/lib/public-butecos") as {
+      getButecoBySlug: jest.Mock;
+    };
+
+    getButecoBySlug.mockResolvedValue(null);
+
+    const detailPageModule = (await import("@/app/(public)/butecos/[slug]/page")) as {
+      generateMetadata?: (input: { params: Promise<{ slug: string }> }) => Promise<unknown>;
+    };
+
+    const metadata = await detailPageModule.generateMetadata?.({
+      params: Promise.resolve({ slug: "inexistente" }),
+    });
+
+    expect(metadata).toMatchObject({
+      title: "Buteco não encontrado",
+      robots: {
+        index: false,
+        follow: false,
+      },
+    });
+  });
+});

--- a/apps/web/app/__tests__/sitemap.test.ts
+++ b/apps/web/app/__tests__/sitemap.test.ts
@@ -1,0 +1,53 @@
+jest.mock("@/lib/public-butecos", () => ({
+  listPublicButecoEntriesForSitemap: jest.fn(),
+}));
+
+describe("sitemap", () => {
+  const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.NEXTAUTH_URL = "https://www.ondetembuteco.com.br";
+  });
+
+  afterEach(() => {
+    if (originalNextAuthUrl === undefined) {
+      delete process.env.NEXTAUTH_URL;
+      return;
+    }
+
+    process.env.NEXTAUTH_URL = originalNextAuthUrl;
+  });
+
+  it("returns static and dynamic public URLs", async () => {
+    const { listPublicButecoEntriesForSitemap } = jest.requireMock("@/lib/public-butecos") as {
+      listPublicButecoEntriesForSitemap: jest.Mock;
+    };
+
+    const updatedAt = new Date("2026-04-23T12:00:00.000Z");
+    listPublicButecoEntriesForSitemap.mockResolvedValue([
+      { slug: "bar-do-zeca", updatedAt },
+      { slug: "cantin-do-joao", updatedAt },
+    ]);
+
+    const sitemapModule = await import("@/app/sitemap");
+    const entries = await sitemapModule.default();
+
+    expect(entries).toEqual([
+      {
+        url: "https://www.ondetembuteco.com.br/",
+      },
+      {
+        url: "https://www.ondetembuteco.com.br/butecos",
+      },
+      {
+        url: "https://www.ondetembuteco.com.br/butecos/bar-do-zeca",
+        lastModified: updatedAt,
+      },
+      {
+        url: "https://www.ondetembuteco.com.br/butecos/cantin-do-joao",
+        lastModified: updatedAt,
+      },
+    ]);
+  });
+});

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -15,8 +15,31 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Onde Tem Buteco",
-  description: "Encontre e explore os butecos participantes em um mapa interativo.",
+  metadataBase: new URL(process.env.NEXTAUTH_URL ?? "https://onde-tem-buteco.vercel.app"),
+  title: {
+    default: "Onde Tem Buteco",
+    template: "%s | Onde Tem Buteco",
+  },
+  description:
+    "Encontre os butecos participantes do Comida di Buteco em um mapa interativo, com filtros por cidade e bairro.",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    title: "Onde Tem Buteco",
+    description:
+      "Encontre os butecos participantes do Comida di Buteco em um mapa interativo, com filtros por cidade e bairro.",
+    url: "/",
+    siteName: "Onde Tem Buteco",
+    locale: "pt_BR",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Onde Tem Buteco",
+    description:
+      "Encontre os butecos participantes do Comida di Buteco em um mapa interativo, com filtros por cidade e bairro.",
+  },
 };
 
 const themeScript = `

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+import { listPublicButecoEntriesForSitemap } from "@/lib/public-butecos";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = new URL(process.env.NEXTAUTH_URL ?? "https://onde-tem-buteco.vercel.app");
+  const butecos = await listPublicButecoEntriesForSitemap();
+
+  return [
+    {
+      url: new URL("/", baseUrl).toString(),
+    },
+    {
+      url: new URL("/butecos", baseUrl).toString(),
+    },
+    ...butecos.map(({ slug, updatedAt }) => ({
+      url: new URL(`/butecos/${slug}`, baseUrl).toString(),
+      lastModified: updatedAt,
+    })),
+  ];
+}

--- a/apps/web/e2e/seo.spec.ts
+++ b/apps/web/e2e/seo.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+test("expõe metadata SEO na página pública de detalhe", async ({ page, baseURL }) => {
+  await page.goto("/butecos/bar-do-zeca");
+
+  await expect(page).toHaveTitle("Bar do Zeca | Onde Tem Buteco");
+  await expect(page.locator('meta[name="description"]').first()).toHaveAttribute(
+    "content",
+    /Bolinho da Casa/
+  );
+  await expect(page.locator('link[rel="canonical"]').first()).toHaveAttribute(
+    "href",
+    `${baseURL}/butecos/bar-do-zeca`
+  );
+  await expect(page.locator('meta[property="og:title"]').first()).toHaveAttribute(
+    "content",
+    "Bar do Zeca"
+  );
+});
+
+test("marca detalhe inexistente como noindex", async ({ page }) => {
+  await page.goto("/butecos/inexistente");
+
+  await expect(page.locator('meta[name="robots"]').first()).toHaveAttribute("content", /noindex/i);
+});
+
+test("serve sitemap.xml com rotas públicas e detalhes", async ({ request, baseURL }) => {
+  const response = await request.get("/sitemap.xml");
+
+  expect(response.ok()).toBe(true);
+
+  const body = await response.text();
+
+  expect(body).toContain(`${baseURL}/`);
+  expect(body).toContain(`${baseURL}/butecos`);
+  expect(body).toContain(`${baseURL}/butecos/bar-do-zeca`);
+});

--- a/apps/web/lib/__tests__/public-butecos.test.ts
+++ b/apps/web/lib/__tests__/public-butecos.test.ts
@@ -13,6 +13,7 @@ import {
   getButecosPageData,
   getHomeData,
   isE2EFixtureMode,
+  listPublicButecoEntriesForSitemap,
 } from "@/lib/public-butecos";
 
 const { prisma } = jest.requireMock("@/lib/prisma") as {
@@ -89,6 +90,7 @@ describe("public-butecos fixtures", () => {
 
   it("returns detailed data for a known slug and null for an unknown one", async () => {
     await expect(getButecoBySlug("bar-do-zeca")).resolves.toEqual({
+      id: "fixture-bar-do-zeca",
       slug: "bar-do-zeca",
       nome: "Bar do Zeca",
       cidade: "Belo Horizonte",
@@ -102,6 +104,23 @@ describe("public-butecos fixtures", () => {
     });
 
     await expect(getButecoBySlug("inexistente")).resolves.toBeNull();
+  });
+
+  it("lists sitemap entries from fixtures", async () => {
+    await expect(listPublicButecoEntriesForSitemap()).resolves.toEqual([
+      {
+        slug: "bar-do-zeca",
+        updatedAt: undefined,
+      },
+      {
+        slug: "cantin-do-joao",
+        updatedAt: undefined,
+      },
+      {
+        slug: "esquina-da-celia",
+        updatedAt: undefined,
+      },
+    ]);
   });
 });
 
@@ -190,5 +209,19 @@ describe("public-butecos prisma mode", () => {
       petiscoDesc: "Bolinho crocante de carne com molho da casa.",
       fotoUrl: null,
     });
+  });
+
+  it("lists sitemap entries from prisma when fixture mode is disabled", async () => {
+    const updatedAt = new Date("2026-04-23T12:00:00.000Z");
+
+    prisma.buteco.findMany.mockResolvedValue([
+      { slug: "bar-do-zeca", updatedAt },
+      { slug: "cantin-do-joao", updatedAt },
+    ]);
+
+    await expect(listPublicButecoEntriesForSitemap()).resolves.toEqual([
+      { slug: "bar-do-zeca", updatedAt },
+      { slug: "cantin-do-joao", updatedAt },
+    ]);
   });
 });

--- a/apps/web/lib/public-butecos.ts
+++ b/apps/web/lib/public-butecos.ts
@@ -21,6 +21,7 @@ export type PublicButecoMapItem = {
 };
 
 export type PublicButecoDetail = {
+  id: string;
   slug: string;
   nome: string;
   cidade: string;
@@ -36,10 +37,12 @@ export type PublicButecoDetail = {
 type PublicButecoRecord = PublicButecoDetail & {
   lat: number | null;
   lng: number | null;
+  updatedAt?: Date;
 };
 
 const e2eFixtureButecos: PublicButecoRecord[] = [
   {
+    id: "fixture-bar-do-zeca",
     slug: "bar-do-zeca",
     nome: "Bar do Zeca",
     cidade: "Belo Horizonte",
@@ -54,6 +57,7 @@ const e2eFixtureButecos: PublicButecoRecord[] = [
     lng: -43.9342,
   },
   {
+    id: "fixture-cantin-do-joao",
     slug: "cantin-do-joao",
     nome: "Cantin do João",
     cidade: "Belo Horizonte",
@@ -68,6 +72,7 @@ const e2eFixtureButecos: PublicButecoRecord[] = [
     lng: -43.9386,
   },
   {
+    id: "fixture-esquina-da-celia",
     slug: "esquina-da-celia",
     nome: "Esquina da Célia",
     cidade: "Contagem",
@@ -255,6 +260,7 @@ export async function getButecoBySlug(slug: string): Promise<PublicButecoDetail 
     }
 
     return {
+      id: buteco.id,
       slug: buteco.slug,
       nome: buteco.nome,
       cidade: buteco.cidade,
@@ -271,5 +277,22 @@ export async function getButecoBySlug(slug: string): Promise<PublicButecoDetail 
   const { prisma } = await import("@/lib/prisma");
   return prisma.buteco.findUnique({
     where: { slug },
+  });
+}
+
+export async function listPublicButecoEntriesForSitemap(): Promise<
+  Array<{ slug: string; updatedAt?: Date }>
+> {
+  if (isE2EFixtureMode()) {
+    return e2eFixtureButecos.map(({ slug, updatedAt }) => ({ slug, updatedAt }));
+  }
+
+  const { prisma } = await import("@/lib/prisma");
+  return prisma.buteco.findMany({
+    orderBy: { slug: "asc" },
+    select: {
+      slug: true,
+      updatedAt: true,
+    },
   });
 }


### PR DESCRIPTION
﻿## O que mudou
- Adiciona metadata base, Open Graph e Twitter cards para as páginas públicas.
- Gera metadata dinâmica para detalhe de buteco e `sitemap.xml` com home, listagem e detalhes.
- Isola helpers de leitura pública para SEO e sitemap com cobertura unitária.

## Validação
- `pnpm format:check`
- `pnpm lint`
- `pnpm test -- --runInBand`
- `pnpm test:e2e`

Closes #39
