### PR TITLE
feat: adiciona ações no detalhe do buteco

### DIFF
--- a/apps/web/app/(public)/butecos/[slug]/__tests__/page.test.tsx
+++ b/apps/web/app/(public)/butecos/[slug]/__tests__/page.test.tsx
@@ -1,0 +1,107 @@
+/** @jest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import ButecoPage from "@/app/(public)/butecos/[slug]/page";
+import { getButecoActionState } from "@/lib/detail-actions";
+import { getButecoBySlug } from "@/lib/public-butecos";
+import { notFound } from "next/navigation";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+jest.mock("next/image", () => {
+  return function MockImage(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img {...props} alt={props.alt ?? ""} />;
+  };
+});
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(),
+}));
+
+jest.mock("@/lib/public-butecos", () => ({
+  getButecoBySlug: jest.fn(),
+}));
+
+jest.mock("@/lib/detail-actions", () => ({
+  getButecoActionState: jest.fn(),
+}));
+
+jest.mock("@/components/butecos/buteco-action-panel", () => ({
+  __esModule: true,
+  default: function MockButecoActionPanel(props: Record<string, unknown>) {
+    return <pre data-testid="buteco-action-panel">{JSON.stringify(props)}</pre>;
+  },
+}));
+
+const getButecoBySlugMock = getButecoBySlug as jest.Mock;
+const getButecoActionStateMock = getButecoActionState as jest.Mock;
+const notFoundMock = notFound as jest.Mock;
+
+describe("ButecoPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the detail page and passes the auth-aware state to the action panel", async () => {
+    getButecoBySlugMock.mockResolvedValue({
+      id: "fixture-bar-do-zeca",
+      slug: "bar-do-zeca",
+      nome: "Bar do Zeca",
+      cidade: "Belo Horizonte",
+      bairro: "Savassi",
+      endereco: "Rua dos Testes, 123 - Savassi, Belo Horizonte - MG",
+      telefone: "(31) 3333-1111",
+      horario: "Seg a Sáb, 18h às 23h",
+      petiscoNome: "Bolinho da Casa",
+      petiscoDesc: "Bolinho crocante de carne com molho da casa.",
+      fotoUrl: null,
+    });
+    getButecoActionStateMock.mockResolvedValue({
+      isAuthenticated: false,
+      isFavorito: false,
+      isVisitado: false,
+      loginHref: "/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca",
+    });
+
+    render(await ButecoPage({ params: Promise.resolve({ slug: "bar-do-zeca" }) }));
+
+    expect(screen.getByRole("heading", { name: "Bar do Zeca" })).toBeVisible();
+    expect(screen.getByText("Savassi, Belo Horizonte")).toBeVisible();
+    expect(screen.getByText("Rua dos Testes, 123 - Savassi, Belo Horizonte - MG")).toBeVisible();
+    expect(screen.getByTestId("buteco-action-panel")).toHaveTextContent(
+      JSON.stringify({
+        butecoId: "fixture-bar-do-zeca",
+        loginHref: "/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca",
+        isAuthenticated: false,
+        initialIsFavorito: false,
+        initialIsVisitado: false,
+      })
+    );
+    expect(getButecoActionStateMock).toHaveBeenCalledWith({
+      butecoId: "fixture-bar-do-zeca",
+      slug: "bar-do-zeca",
+    });
+  });
+
+  it("delegates to notFound when the buteco does not exist", async () => {
+    getButecoBySlugMock.mockResolvedValue(null);
+
+    await ButecoPage({ params: Promise.resolve({ slug: "inexistente" }) });
+
+    expect(notFoundMock).toHaveBeenCalled();
+    expect(getButecoActionStateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/(public)/butecos/[slug]/page.tsx
+++ b/apps/web/app/(public)/butecos/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import ButecoActionPanel from "@/components/butecos/buteco-action-panel";
+import { getButecoActionState } from "@/lib/detail-actions";
 import { getButecoBySlug } from "@/lib/public-butecos";
 
 export default async function ButecoPage({
@@ -10,7 +12,15 @@ export default async function ButecoPage({
 
   const buteco = await getButecoBySlug(slug);
 
-  if (!buteco) notFound();
+  if (!buteco) {
+    notFound();
+    return null;
+  }
+
+  const actionState = await getButecoActionState({
+    butecoId: buteco.id,
+    slug: buteco.slug,
+  });
 
   return (
     <main className="max-w-2xl mx-auto px-4 py-8">
@@ -47,6 +57,13 @@ export default async function ButecoPage({
         {buteco.telefone && <p>{buteco.telefone}</p>}
         {buteco.horario && <p>{buteco.horario}</p>}
       </div>
+      <ButecoActionPanel
+        butecoId={buteco.id}
+        loginHref={actionState.loginHref}
+        isAuthenticated={actionState.isAuthenticated}
+        initialIsFavorito={actionState.isFavorito}
+        initialIsVisitado={actionState.isVisitado}
+      />
     </main>
   );
 }

--- a/apps/web/app/api/butecos/__tests__/route.test.ts
+++ b/apps/web/app/api/butecos/__tests__/route.test.ts
@@ -22,8 +22,20 @@ const { prisma } = jest.requireMock("@/lib/prisma") as {
 };
 
 describe("POST /api/butecos", () => {
+  const originalFixtureMode = process.env.E2E_USE_FIXTURES;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    delete process.env.E2E_USE_FIXTURES;
+  });
+
+  afterEach(() => {
+    if (originalFixtureMode === undefined) {
+      delete process.env.E2E_USE_FIXTURES;
+      return;
+    }
+
+    process.env.E2E_USE_FIXTURES = originalFixtureMode;
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -47,6 +59,20 @@ describe("POST /api/butecos", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "Ação inválida" });
+  });
+
+  it("returns 400 when butecoId is missing", async () => {
+    auth.mockResolvedValue({ user: { email: "test@example.com" } });
+
+    const response = await POST(
+      new Request("https://localhost/api/butecos", {
+        method: "POST",
+        body: JSON.stringify({ butecoId: "", action: "favoritar" }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Buteco inválido" });
   });
 
   it("returns 404 when user is not found", async () => {
@@ -115,5 +141,30 @@ describe("POST /api/butecos", () => {
       update: {},
       create: { userId: "user-1", butecoId: "buteco-1" },
     });
+  });
+
+  it("uses fixture auth cookies when e2e fixture mode is enabled", async () => {
+    process.env.E2E_USE_FIXTURES = "true";
+
+    const response = await POST(
+      new Request("https://localhost/api/butecos", {
+        method: "POST",
+        headers: {
+          cookie:
+            "onde-tem-buteco-e2e-auth=authenticated; onde-tem-buteco-e2e-favoritos=%5B%5D; onde-tem-buteco-e2e-visitas=%5B%5D",
+        },
+        body: JSON.stringify({ butecoId: "fixture-bar-do-zeca", action: "favoritar" }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      isFavorito: true,
+      isVisitado: false,
+    });
+    expect(response.headers.get("set-cookie")).toContain("onde-tem-buteco-e2e-favoritos=");
+    expect(auth).not.toHaveBeenCalled();
+    expect(prisma.favorito.upsert).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/butecos/__tests__/route.test.ts
+++ b/apps/web/app/api/butecos/__tests__/route.test.ts
@@ -47,6 +47,21 @@ describe("POST /api/butecos", () => {
     await expect(response.json()).resolves.toEqual({ error: "Não autorizado" });
   });
 
+  it("returns 400 when the request body is not valid JSON", async () => {
+    auth.mockResolvedValue({ user: { email: "test@example.com" } });
+
+    const response = await POST(
+      new Request("https://localhost/api/butecos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Requisição inválida" });
+  });
+
   it("returns 400 for invalid action", async () => {
     auth.mockResolvedValue({ user: { email: "test@example.com" } });
 

--- a/apps/web/app/api/butecos/route.ts
+++ b/apps/web/app/api/butecos/route.ts
@@ -5,6 +5,11 @@ import { E2E_AUTH_COOKIE, E2E_FAVORITOS_COOKIE, E2E_VISITAS_COOKIE } from "@/lib
 import { prisma } from "@/lib/prisma";
 import { isE2EFixtureMode } from "@/lib/public-butecos";
 
+type ActionRequestBody = {
+  butecoId: string;
+  action: string;
+};
+
 function parseCookieHeader(cookieHeader: string | null): Map<string, string> {
   const cookies = new Map<string, string>();
 
@@ -52,10 +57,11 @@ function toCookieValue(values: string[]): string {
   return encodeURIComponent(JSON.stringify(values));
 }
 
-async function parseActionRequest(request: Request): Promise<{
-  butecoId: string;
-  action: string;
-} | null> {
+function buildErrorResponse(message: string, status: number) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+async function parseActionRequest(request: Request): Promise<ActionRequestBody | null> {
   try {
     const body = await request.json();
 
@@ -74,108 +80,153 @@ async function parseActionRequest(request: Request): Promise<{
   }
 }
 
-export async function POST(request: Request) {
-  if (isE2EFixtureMode()) {
-    const requestCookies = parseCookieHeader(request.headers.get("cookie"));
-
-    if (requestCookies.get(E2E_AUTH_COOKIE) !== "authenticated") {
-      return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
-    }
-
-    const body = await parseActionRequest(request);
-
-    if (!body) {
-      return NextResponse.json({ error: "Requisição inválida" }, { status: 400 });
-    }
-
-    const { butecoId, action } = body;
-
-    if (!isValidAction(action)) {
-      return NextResponse.json({ error: "Ação inválida" }, { status: 400 });
-    }
-
-    if (!butecoId.trim()) {
-      return NextResponse.json({ error: "Buteco inválido" }, { status: 400 });
-    }
-
-    const favoritos = parseCookieList(requestCookies.get(E2E_FAVORITOS_COOKIE));
-    const visitas = parseCookieList(requestCookies.get(E2E_VISITAS_COOKIE));
-
-    const nextFavoritos = new Set(favoritos);
-    const nextVisitas = new Set(visitas);
-
-    if (action === "favoritar") {
-      nextFavoritos.add(butecoId);
-    } else if (action === "desfavoritar") {
-      nextFavoritos.delete(butecoId);
-    } else if (action === "visitar") {
-      nextVisitas.add(butecoId);
-    }
-
-    const response = NextResponse.json({
-      ok: true,
-      isFavorito: nextFavoritos.has(butecoId),
-      isVisitado: nextVisitas.has(butecoId),
-    });
-
-    response.cookies.set(E2E_FAVORITOS_COOKIE, toCookieValue([...nextFavoritos]), { path: "/" });
-    response.cookies.set(E2E_VISITAS_COOKIE, toCookieValue([...nextVisitas]), { path: "/" });
-
-    return response;
-  }
-
-  const session = await auth();
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
-  }
-
-  const body = await parseActionRequest(request);
-
+function validateActionRequest(body: ActionRequestBody | null): ActionRequestBody | NextResponse {
   if (!body) {
-    return NextResponse.json({ error: "Requisição inválida" }, { status: 400 });
+    return buildErrorResponse("Requisição inválida", 400);
   }
 
-  const { butecoId, action } = body;
-
-  if (!isValidAction(action)) {
-    return NextResponse.json({ error: "Ação inválida" }, { status: 400 });
+  if (!isValidAction(body.action)) {
+    return buildErrorResponse("Ação inválida", 400);
   }
 
-  if (!butecoId.trim()) {
-    return NextResponse.json({ error: "Buteco inválido" }, { status: 400 });
+  if (!body.butecoId.trim()) {
+    return buildErrorResponse("Buteco inválido", 400);
   }
 
+  return body;
+}
+
+function applyFixtureAction(
+  action: string,
+  butecoId: string,
+  favoritos: string[],
+  visitas: string[]
+) {
+  const nextFavoritos = new Set(favoritos);
+  const nextVisitas = new Set(visitas);
+
+  if (action === "favoritar") {
+    nextFavoritos.add(butecoId);
+  } else if (action === "desfavoritar") {
+    nextFavoritos.delete(butecoId);
+  } else if (action === "visitar") {
+    nextVisitas.add(butecoId);
+  }
+
+  return {
+    isFavorito: nextFavoritos.has(butecoId),
+    isVisitado: nextVisitas.has(butecoId),
+    favoritos: [...nextFavoritos],
+    visitas: [...nextVisitas],
+  };
+}
+
+function buildFixtureResponse(result: {
+  isFavorito: boolean;
+  isVisitado: boolean;
+  favoritos: string[];
+  visitas: string[];
+}) {
+  const response = NextResponse.json({
+    ok: true,
+    isFavorito: result.isFavorito,
+    isVisitado: result.isVisitado,
+  });
+
+  response.cookies.set(E2E_FAVORITOS_COOKIE, toCookieValue(result.favoritos), { path: "/" });
+  response.cookies.set(E2E_VISITAS_COOKIE, toCookieValue(result.visitas), { path: "/" });
+
+  return response;
+}
+
+async function handleFixtureRequest(request: Request, body: ActionRequestBody) {
+  const requestCookies = parseCookieHeader(request.headers.get("cookie"));
+
+  if (requestCookies.get(E2E_AUTH_COOKIE) !== "authenticated") {
+    return buildErrorResponse("Não autorizado", 401);
+  }
+
+  const favoritos = parseCookieList(requestCookies.get(E2E_FAVORITOS_COOKIE));
+  const visitas = parseCookieList(requestCookies.get(E2E_VISITAS_COOKIE));
+
+  return buildFixtureResponse(applyFixtureAction(body.action, body.butecoId, favoritos, visitas));
+}
+
+async function loadUserId(userEmail: string) {
   const user = await prisma.user.findUnique({
-    where: { email: session.user.email },
+    where: { email: userEmail },
     select: { id: true },
   });
 
   if (!user) {
-    return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404 });
+    return null;
   }
 
-  let isFavorito = false;
-  let isVisitado = false;
+  return user.id;
+}
 
-  if (action === "favoritar") {
+async function persistAction(userId: string, body: ActionRequestBody) {
+  if (body.action === "favoritar") {
     await prisma.favorito.upsert({
-      where: { userId_butecoId: { userId: user.id, butecoId } },
+      where: { userId_butecoId: { userId, butecoId: body.butecoId } },
       update: {},
-      create: { userId: user.id, butecoId },
+      create: { userId, butecoId: body.butecoId },
     });
-    isFavorito = true;
-  } else if (action === "desfavoritar") {
-    await prisma.favorito.deleteMany({
-      where: { userId: user.id, butecoId },
-    });
-  } else if (action === "visitar") {
-    await prisma.visita.upsert({
-      where: { userId_butecoId: { userId: user.id, butecoId } },
-      update: {},
-      create: { userId: user.id, butecoId },
-    });
-    isVisitado = true;
+
+    return { isFavorito: true, isVisitado: false };
   }
 
-  return NextResponse.json({ ok: true, isFavorito, isVisitado });
+  if (body.action === "desfavoritar") {
+    await prisma.favorito.deleteMany({
+      where: { userId, butecoId: body.butecoId },
+    });
+
+    return { isFavorito: false, isVisitado: false };
+  }
+
+  await prisma.visita.upsert({
+    where: { userId_butecoId: { userId, butecoId: body.butecoId } },
+    update: {},
+    create: { userId, butecoId: body.butecoId },
+  });
+
+  return { isFavorito: false, isVisitado: true };
+}
+
+async function handlePersistedRequest(body: ActionRequestBody, userEmail: string) {
+  const userId = await loadUserId(userEmail);
+
+  if (!userId) {
+    return buildErrorResponse("Usuário não encontrado", 404);
+  }
+
+  const result = await persistAction(userId, body);
+
+  return NextResponse.json({ ok: true, ...result });
+}
+
+export async function POST(request: Request) {
+  if (isE2EFixtureMode()) {
+    const parsedBody = validateActionRequest(await parseActionRequest(request));
+
+    if (parsedBody instanceof NextResponse) {
+      return parsedBody;
+    }
+
+    return handleFixtureRequest(request, parsedBody);
+  }
+
+  const session = await auth();
+
+  if (!session?.user?.email) {
+    return buildErrorResponse("Não autorizado", 401);
+  }
+
+  const parsedBody = validateActionRequest(await parseActionRequest(request));
+
+  if (parsedBody instanceof NextResponse) {
+    return parsedBody;
+  }
+
+  return handlePersistedRequest(parsedBody, session.user.email);
 }

--- a/apps/web/app/api/butecos/route.ts
+++ b/apps/web/app/api/butecos/route.ts
@@ -1,29 +1,136 @@
 import { NextResponse } from "next/server";
 import { isValidAction } from "@/lib/buteco-actions";
 import { auth } from "@/lib/auth";
+import { E2E_AUTH_COOKIE, E2E_FAVORITOS_COOKIE, E2E_VISITAS_COOKIE } from "@/lib/detail-actions";
 import { prisma } from "@/lib/prisma";
+import { isE2EFixtureMode } from "@/lib/public-butecos";
+
+function parseCookieHeader(cookieHeader: string | null): Map<string, string> {
+  const cookies = new Map<string, string>();
+
+  if (!cookieHeader) {
+    return cookies;
+  }
+
+  for (const segment of cookieHeader.split(";")) {
+    const [name, ...valueParts] = segment.trim().split("=");
+
+    if (!name) {
+      continue;
+    }
+
+    cookies.set(name, valueParts.join("="));
+  }
+
+  return cookies;
+}
+
+function parseCookieList(rawValue: string | undefined): string[] {
+  if (!rawValue) {
+    return [];
+  }
+
+  const candidates = [rawValue];
+
+  try {
+    candidates.push(decodeURIComponent(rawValue));
+  } catch {}
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (Array.isArray(parsed)) {
+        return parsed.filter((item): item is string => typeof item === "string");
+      }
+    } catch {}
+  }
+
+  return [];
+}
+
+function toCookieValue(values: string[]): string {
+  return encodeURIComponent(JSON.stringify(values));
+}
+
+async function parseActionRequest(request: Request): Promise<{
+  butecoId: string;
+  action: string;
+}> {
+  return (await request.json()) as {
+    butecoId: string;
+    action: string;
+  };
+}
 
 export async function POST(request: Request) {
+  if (isE2EFixtureMode()) {
+    const requestCookies = parseCookieHeader(request.headers.get("cookie"));
+
+    if (requestCookies.get(E2E_AUTH_COOKIE) !== "authenticated") {
+      return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
+    }
+
+    const { butecoId, action } = await parseActionRequest(request);
+
+    if (!isValidAction(action)) {
+      return NextResponse.json({ error: "Ação inválida" }, { status: 400 });
+    }
+
+    if (!butecoId.trim()) {
+      return NextResponse.json({ error: "Buteco inválido" }, { status: 400 });
+    }
+
+    const favoritos = parseCookieList(requestCookies.get(E2E_FAVORITOS_COOKIE));
+    const visitas = parseCookieList(requestCookies.get(E2E_VISITAS_COOKIE));
+
+    const nextFavoritos = new Set(favoritos);
+    const nextVisitas = new Set(visitas);
+
+    if (action === "favoritar") {
+      nextFavoritos.add(butecoId);
+    } else if (action === "desfavoritar") {
+      nextFavoritos.delete(butecoId);
+    } else if (action === "visitar") {
+      nextVisitas.add(butecoId);
+    }
+
+    const response = NextResponse.json({
+      ok: true,
+      isFavorito: nextFavoritos.has(butecoId),
+      isVisitado: nextVisitas.has(butecoId),
+    });
+
+    response.cookies.set(E2E_FAVORITOS_COOKIE, toCookieValue([...nextFavoritos]), { path: "/" });
+    response.cookies.set(E2E_VISITAS_COOKIE, toCookieValue([...nextVisitas]), { path: "/" });
+
+    return response;
+  }
+
   const session = await auth();
   if (!session?.user?.email) {
     return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
   }
 
-  const { butecoId, action } = (await request.json()) as {
-    butecoId: string;
-    action: string;
-  };
+  const { butecoId, action } = await parseActionRequest(request);
 
   if (!isValidAction(action)) {
     return NextResponse.json({ error: "Ação inválida" }, { status: 400 });
   }
 
+  if (!butecoId.trim()) {
+    return NextResponse.json({ error: "Buteco inválido" }, { status: 400 });
+  }
+
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },
   });
+
   if (!user) {
     return NextResponse.json({ error: "Usuário não encontrado" }, { status: 404 });
   }
+
+  let isFavorito = false;
+  let isVisitado = false;
 
   if (action === "favoritar") {
     await prisma.favorito.upsert({
@@ -31,6 +138,7 @@ export async function POST(request: Request) {
       update: {},
       create: { userId: user.id, butecoId },
     });
+    isFavorito = true;
   } else if (action === "desfavoritar") {
     await prisma.favorito.deleteMany({
       where: { userId: user.id, butecoId },
@@ -41,7 +149,8 @@ export async function POST(request: Request) {
       update: {},
       create: { userId: user.id, butecoId },
     });
+    isVisitado = true;
   }
 
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, isFavorito, isVisitado });
 }

--- a/apps/web/app/api/butecos/route.ts
+++ b/apps/web/app/api/butecos/route.ts
@@ -55,11 +55,23 @@ function toCookieValue(values: string[]): string {
 async function parseActionRequest(request: Request): Promise<{
   butecoId: string;
   action: string;
-}> {
-  return (await request.json()) as {
-    butecoId: string;
-    action: string;
-  };
+} | null> {
+  try {
+    const body = await request.json();
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return null;
+    }
+
+    const { butecoId, action } = body as Record<string, unknown>;
+
+    return {
+      butecoId: typeof butecoId === "string" ? butecoId : "",
+      action: typeof action === "string" ? action : "",
+    };
+  } catch {
+    return null;
+  }
 }
 
 export async function POST(request: Request) {
@@ -70,7 +82,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
     }
 
-    const { butecoId, action } = await parseActionRequest(request);
+    const body = await parseActionRequest(request);
+
+    if (!body) {
+      return NextResponse.json({ error: "Requisição inválida" }, { status: 400 });
+    }
+
+    const { butecoId, action } = body;
 
     if (!isValidAction(action)) {
       return NextResponse.json({ error: "Ação inválida" }, { status: 400 });
@@ -111,7 +129,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
   }
 
-  const { butecoId, action } = await parseActionRequest(request);
+  const body = await parseActionRequest(request);
+
+  if (!body) {
+    return NextResponse.json({ error: "Requisição inválida" }, { status: 400 });
+  }
+
+  const { butecoId, action } = body;
 
   if (!isValidAction(action)) {
     return NextResponse.json({ error: "Ação inválida" }, { status: 400 });
@@ -123,6 +147,7 @@ export async function POST(request: Request) {
 
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },
+    select: { id: true },
   });
 
   if (!user) {

--- a/apps/web/components/butecos/__tests__/buteco-action-panel.test.tsx
+++ b/apps/web/components/butecos/__tests__/buteco-action-panel.test.tsx
@@ -1,0 +1,130 @@
+/** @jest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ButecoActionPanel from "@/components/butecos/buteco-action-panel";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+describe("ButecoActionPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it("renders a clear login CTA for anonymous users", () => {
+    render(
+      <ButecoActionPanel
+        butecoId="fixture-bar-do-zeca"
+        loginHref="/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca"
+        isAuthenticated={false}
+        initialIsFavorito={false}
+        initialIsVisitado={false}
+      />
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Faça login para favoritar e registrar visita" })
+    ).toHaveAttribute("href", "/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca");
+    expect(screen.queryByRole("button", { name: "Favoritar" })).not.toBeInTheDocument();
+  });
+
+  it("toggles favorite state after a successful mutation", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+
+    render(
+      <ButecoActionPanel
+        butecoId="fixture-bar-do-zeca"
+        loginHref="/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca"
+        isAuthenticated={true}
+        initialIsFavorito={false}
+        initialIsVisitado={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Favoritar" }));
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/butecos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          butecoId: "fixture-bar-do-zeca",
+          action: "favoritar",
+        }),
+      })
+    );
+
+    expect(await screen.findByText("Buteco adicionado aos favoritos.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Remover dos favoritos" })).toBeVisible();
+  });
+
+  it("marks the buteco as visited and disables the visit button", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+
+    render(
+      <ButecoActionPanel
+        butecoId="fixture-bar-do-zeca"
+        loginHref="/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca"
+        isAuthenticated={true}
+        initialIsFavorito={false}
+        initialIsVisitado={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Marcar como visitado" }));
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/butecos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          butecoId: "fixture-bar-do-zeca",
+          action: "visitar",
+        }),
+      })
+    );
+
+    expect(await screen.findByText("Visita registrada com sucesso.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Visitado" })).toBeDisabled();
+  });
+
+  it("shows an inline error when the mutation fails", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Não foi possível atualizar a ação." }),
+    });
+
+    render(
+      <ButecoActionPanel
+        butecoId="fixture-bar-do-zeca"
+        loginHref="/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca"
+        isAuthenticated={true}
+        initialIsFavorito={true}
+        initialIsVisitado={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remover dos favoritos" }));
+
+    expect(await screen.findByText("Não foi possível atualizar a ação.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Remover dos favoritos" })).toBeVisible();
+  });
+});

--- a/apps/web/components/butecos/buteco-action-panel.tsx
+++ b/apps/web/components/butecos/buteco-action-panel.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+type ButecoActionPanelProps = {
+  butecoId: string;
+  loginHref: string;
+  isAuthenticated: boolean;
+  initialIsFavorito: boolean;
+  initialIsVisitado: boolean;
+};
+
+type Feedback = {
+  type: "success" | "error";
+  message: string;
+} | null;
+
+async function mutateButecoAction(
+  butecoId: string,
+  action: "favoritar" | "desfavoritar" | "visitar"
+) {
+  const response = await fetch("/api/butecos", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ butecoId, action }),
+  });
+
+  const payload = (await response.json()) as { error?: string };
+
+  if (!response.ok) {
+    throw new Error(payload.error ?? "Não foi possível atualizar a ação.");
+  }
+}
+
+export default function ButecoActionPanel({
+  butecoId,
+  loginHref,
+  isAuthenticated,
+  initialIsFavorito,
+  initialIsVisitado,
+}: ButecoActionPanelProps) {
+  const [isFavorito, setIsFavorito] = useState(initialIsFavorito);
+  const [isVisitado, setIsVisitado] = useState(initialIsVisitado);
+  const [pendingAction, setPendingAction] = useState<"favorito" | "visita" | null>(null);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+
+  async function handleFavoritoClick() {
+    const action = isFavorito ? "desfavoritar" : "favoritar";
+    setPendingAction("favorito");
+    setFeedback(null);
+
+    try {
+      await mutateButecoAction(butecoId, action);
+      setIsFavorito(!isFavorito);
+      setFeedback({
+        type: "success",
+        message: isFavorito ? "Buteco removido dos favoritos." : "Buteco adicionado aos favoritos.",
+      });
+    } catch (error) {
+      setFeedback({
+        type: "error",
+        message: error instanceof Error ? error.message : "Não foi possível atualizar a ação.",
+      });
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function handleVisitaClick() {
+    setPendingAction("visita");
+    setFeedback(null);
+
+    try {
+      await mutateButecoAction(butecoId, "visitar");
+      setIsVisitado(true);
+      setFeedback({
+        type: "success",
+        message: "Visita registrada com sucesso.",
+      });
+    } catch (error) {
+      setFeedback({
+        type: "error",
+        message: error instanceof Error ? error.message : "Não foi possível atualizar a ação.",
+      });
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  return (
+    <section className="mt-8 rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
+      <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">Suas ações</h2>
+      <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+        Salve este buteco ou registre que ele já entrou no seu roteiro.
+      </p>
+
+      {!isAuthenticated ? (
+        <div className="mt-4">
+          <Link
+            href={loginHref}
+            className="inline-flex rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600"
+          >
+            Faça login para favoritar e registrar visita
+          </Link>
+        </div>
+      ) : (
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleFavoritoClick}
+            disabled={pendingAction !== null}
+            className="rounded-full border border-zinc-300 px-4 py-2 text-sm font-semibold text-zinc-800 transition hover:border-amber-400 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700 dark:text-zinc-100 dark:hover:border-amber-500 dark:hover:bg-amber-950/40"
+          >
+            {isFavorito ? "Remover dos favoritos" : "Favoritar"}
+          </button>
+          <button
+            type="button"
+            onClick={handleVisitaClick}
+            disabled={isVisitado || pendingAction !== null}
+            className="rounded-full bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-800/70"
+          >
+            {isVisitado ? "Visitado" : "Marcar como visitado"}
+          </button>
+        </div>
+      )}
+
+      {feedback ? (
+        <p
+          className={`mt-3 text-sm ${
+            feedback.type === "error"
+              ? "text-red-600 dark:text-red-400"
+              : "text-emerald-700 dark:text-emerald-400"
+          }`}
+        >
+          {feedback.message}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/e2e/public-flows.spec.ts
+++ b/apps/web/e2e/public-flows.spec.ts
@@ -1,5 +1,25 @@
 import { expect, test } from "@playwright/test";
 
+async function signInWithFixtureCookies(page: import("@playwright/test").Page) {
+  await page.context().addCookies([
+    {
+      name: "onde-tem-buteco-e2e-auth",
+      value: "authenticated",
+      url: "http://127.0.0.1:3000",
+    },
+    {
+      name: "onde-tem-buteco-e2e-favoritos",
+      value: "[]",
+      url: "http://127.0.0.1:3000",
+    },
+    {
+      name: "onde-tem-buteco-e2e-visitas",
+      value: "[]",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
 test("carrega a home pública com os elementos principais", async ({ page }) => {
   await page.goto("/");
 
@@ -89,4 +109,41 @@ test("renderiza os dados principais da página de detalhe", async ({ page }) => 
   await expect(page.getByRole("heading", { name: "Bolinho da Casa" })).toBeVisible();
   await expect(page.getByText("Rua dos Testes, 123 - Savassi, Belo Horizonte - MG")).toBeVisible();
   await expect(page.getByText("(31) 3333-1111")).toBeVisible();
+});
+
+test("exibe CTA de login na página de detalhe para usuário anônimo", async ({ page }) => {
+  await page.goto("/butecos/bar-do-zeca");
+
+  await expect(
+    page.getByRole("link", { name: "Faça login para favoritar e registrar visita" })
+  ).toHaveAttribute("href", "/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca");
+  await expect(page.getByRole("button", { name: "Favoritar" })).toHaveCount(0);
+});
+
+test("permite favoritar, desfavoritar e registrar visita com sessão mockada em fixture mode", async ({
+  page,
+}) => {
+  await signInWithFixtureCookies(page);
+  await page.goto("/butecos/bar-do-zeca");
+
+  await expect(page.getByRole("button", { name: "Favoritar" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Marcar como visitado" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Favoritar" }).click();
+  await expect(page.getByText("Buteco adicionado aos favoritos.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Remover dos favoritos" })).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByRole("button", { name: "Remover dos favoritos" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Remover dos favoritos" }).click();
+  await expect(page.getByText("Buteco removido dos favoritos.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Favoritar" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Marcar como visitado" }).click();
+  await expect(page.getByText("Visita registrada com sucesso.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Visitado" })).toBeDisabled();
+
+  await page.reload();
+  await expect(page.getByRole("button", { name: "Visitado" })).toBeDisabled();
 });

--- a/apps/web/lib/__tests__/detail-actions.test.ts
+++ b/apps/web/lib/__tests__/detail-actions.test.ts
@@ -1,0 +1,139 @@
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+
+jest.mock("@/lib/auth", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    favorito: { findUnique: jest.fn() },
+    visita: { findUnique: jest.fn() },
+  },
+}));
+
+import { cookies } from "next/headers";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { buildButecoLoginHref, getButecoActionState } from "@/lib/detail-actions";
+
+const cookiesMock = cookies as jest.Mock;
+const authMock = auth as jest.Mock;
+const prismaMock = prisma as {
+  user: { findUnique: jest.Mock };
+  favorito: { findUnique: jest.Mock };
+  visita: { findUnique: jest.Mock };
+};
+
+describe("detail-actions", () => {
+  const originalFixtureMode = process.env.E2E_USE_FIXTURES;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.E2E_USE_FIXTURES;
+    cookiesMock.mockResolvedValue({
+      get: jest.fn(() => undefined),
+    });
+  });
+
+  afterEach(() => {
+    if (originalFixtureMode === undefined) {
+      delete process.env.E2E_USE_FIXTURES;
+      return;
+    }
+
+    process.env.E2E_USE_FIXTURES = originalFixtureMode;
+  });
+
+  it("builds the login href with callbackUrl to the detail page", () => {
+    expect(buildButecoLoginHref("bar-do-zeca")).toBe("/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca");
+  });
+
+  it("returns anonymous state in fixture mode when no auth cookie is present", async () => {
+    process.env.E2E_USE_FIXTURES = "true";
+
+    await expect(
+      getButecoActionState({ butecoId: "buteco-1", slug: "bar-do-zeca" })
+    ).resolves.toEqual({
+      isAuthenticated: false,
+      isFavorito: false,
+      isVisitado: false,
+      loginHref: "/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca",
+    });
+  });
+
+  it("returns fixture auth state from cookies when the e2e auth cookie is present", async () => {
+    process.env.E2E_USE_FIXTURES = "true";
+
+    cookiesMock.mockResolvedValue({
+      get: jest.fn((name: string) => {
+        if (name === "onde-tem-buteco-e2e-auth") {
+          return { value: "authenticated" };
+        }
+
+        if (name === "onde-tem-buteco-e2e-favoritos") {
+          return { value: JSON.stringify(["buteco-1"]) };
+        }
+
+        if (name === "onde-tem-buteco-e2e-visitas") {
+          return { value: JSON.stringify(["buteco-1", "buteco-2"]) };
+        }
+
+        return undefined;
+      }),
+    });
+
+    await expect(
+      getButecoActionState({ butecoId: "buteco-1", slug: "bar-do-zeca" })
+    ).resolves.toEqual({
+      isAuthenticated: true,
+      isFavorito: true,
+      isVisitado: true,
+      loginHref: "/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca",
+    });
+  });
+
+  it("returns anonymous state when the real session is missing", async () => {
+    authMock.mockResolvedValue(null);
+
+    await expect(
+      getButecoActionState({ butecoId: "buteco-1", slug: "bar-do-zeca" })
+    ).resolves.toEqual({
+      isAuthenticated: false,
+      isFavorito: false,
+      isVisitado: false,
+      loginHref: "/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca",
+    });
+  });
+
+  it("returns persisted favorite and visit state for authenticated users", async () => {
+    authMock.mockResolvedValue({ user: { email: "test@example.com" } });
+    prismaMock.user.findUnique.mockResolvedValue({ id: "user-1" });
+    prismaMock.favorito.findUnique.mockResolvedValue({ id: "fav-1" });
+    prismaMock.visita.findUnique.mockResolvedValue(null);
+
+    await expect(
+      getButecoActionState({ butecoId: "buteco-1", slug: "bar-do-zeca" })
+    ).resolves.toEqual({
+      isAuthenticated: true,
+      isFavorito: true,
+      isVisitado: false,
+      loginHref: "/login?callbackUrl=%2Fbutecos%2Fbar-do-zeca",
+    });
+
+    expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+      where: { email: "test@example.com" },
+      select: { id: true },
+    });
+    expect(prismaMock.favorito.findUnique).toHaveBeenCalledWith({
+      where: { userId_butecoId: { userId: "user-1", butecoId: "buteco-1" } },
+      select: { id: true },
+    });
+    expect(prismaMock.visita.findUnique).toHaveBeenCalledWith({
+      where: { userId_butecoId: { userId: "user-1", butecoId: "buteco-1" } },
+      select: { id: true },
+    });
+  });
+});

--- a/apps/web/lib/__tests__/public-butecos.test.ts
+++ b/apps/web/lib/__tests__/public-butecos.test.ts
@@ -89,6 +89,7 @@ describe("public-butecos fixtures", () => {
 
   it("returns detailed data for a known slug and null for an unknown one", async () => {
     await expect(getButecoBySlug("bar-do-zeca")).resolves.toEqual({
+      id: "fixture-bar-do-zeca",
       slug: "bar-do-zeca",
       nome: "Bar do Zeca",
       cidade: "Belo Horizonte",
@@ -166,6 +167,7 @@ describe("public-butecos prisma mode", () => {
 
   it("returns detail data from prisma when fixture mode is disabled", async () => {
     prisma.buteco.findUnique.mockResolvedValue({
+      id: "db-bar-do-zeca",
       slug: "bar-do-zeca",
       nome: "Bar do Zeca",
       cidade: "Belo Horizonte",
@@ -179,6 +181,7 @@ describe("public-butecos prisma mode", () => {
     });
 
     await expect(getButecoBySlug("bar-do-zeca")).resolves.toEqual({
+      id: "db-bar-do-zeca",
       slug: "bar-do-zeca",
       nome: "Bar do Zeca",
       cidade: "Belo Horizonte",

--- a/apps/web/lib/detail-actions.ts
+++ b/apps/web/lib/detail-actions.ts
@@ -52,7 +52,9 @@ function parseCookieList(value: string | undefined): string[] {
 }
 
 export function buildButecoLoginHref(slug: string): string {
-  return `/login?callbackUrl=${encodeURIComponent(`/butecos/${slug}`)}`;
+  const callbackUrl = `/butecos/${slug}`;
+
+  return `/login?callbackUrl=${encodeURIComponent(callbackUrl)}`;
 }
 
 export async function getButecoActionState({

--- a/apps/web/lib/detail-actions.ts
+++ b/apps/web/lib/detail-actions.ts
@@ -1,0 +1,115 @@
+import { cookies } from "next/headers";
+import { auth } from "@/lib/auth";
+import { isE2EFixtureMode } from "@/lib/public-butecos";
+import { prisma } from "@/lib/prisma";
+
+export const E2E_AUTH_COOKIE = "onde-tem-buteco-e2e-auth";
+export const E2E_FAVORITOS_COOKIE = "onde-tem-buteco-e2e-favoritos";
+export const E2E_VISITAS_COOKIE = "onde-tem-buteco-e2e-visitas";
+
+type GetButecoActionStateParams = {
+  butecoId: string;
+  slug: string;
+};
+
+export type ButecoActionState = {
+  isAuthenticated: boolean;
+  isFavorito: boolean;
+  isVisitado: boolean;
+  loginHref: string;
+};
+
+function buildDefaultState(slug: string): ButecoActionState {
+  return {
+    isAuthenticated: false,
+    isFavorito: false,
+    isVisitado: false,
+    loginHref: buildButecoLoginHref(slug),
+  };
+}
+
+function parseCookieList(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  const candidates = [value];
+
+  try {
+    candidates.push(decodeURIComponent(value));
+  } catch {}
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (Array.isArray(parsed)) {
+        return parsed.filter((item): item is string => typeof item === "string");
+      }
+    } catch {}
+  }
+
+  return [];
+}
+
+export function buildButecoLoginHref(slug: string): string {
+  return `/login?callbackUrl=${encodeURIComponent(`/butecos/${slug}`)}`;
+}
+
+export async function getButecoActionState({
+  butecoId,
+  slug,
+}: GetButecoActionStateParams): Promise<ButecoActionState> {
+  const defaultState = buildDefaultState(slug);
+
+  if (isE2EFixtureMode()) {
+    const cookieStore = await cookies();
+    const isAuthenticated = cookieStore.get(E2E_AUTH_COOKIE)?.value === "authenticated";
+
+    if (!isAuthenticated) {
+      return defaultState;
+    }
+
+    const favoritos = parseCookieList(cookieStore.get(E2E_FAVORITOS_COOKIE)?.value);
+    const visitas = parseCookieList(cookieStore.get(E2E_VISITAS_COOKIE)?.value);
+
+    return {
+      ...defaultState,
+      isAuthenticated: true,
+      isFavorito: favoritos.includes(butecoId),
+      isVisitado: visitas.includes(butecoId),
+    };
+  }
+
+  const session = await auth();
+
+  if (!session?.user?.email) {
+    return defaultState;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { id: true },
+  });
+
+  if (!user) {
+    return defaultState;
+  }
+
+  const [favorito, visita] = await Promise.all([
+    prisma.favorito.findUnique({
+      where: { userId_butecoId: { userId: user.id, butecoId } },
+      select: { id: true },
+    }),
+    prisma.visita.findUnique({
+      where: { userId_butecoId: { userId: user.id, butecoId } },
+      select: { id: true },
+    }),
+  ]);
+
+  return {
+    ...defaultState,
+    isAuthenticated: true,
+    isFavorito: Boolean(favorito),
+    isVisitado: Boolean(visita),
+  };
+}

--- a/apps/web/lib/public-butecos.ts
+++ b/apps/web/lib/public-butecos.ts
@@ -21,6 +21,7 @@ export type PublicButecoMapItem = {
 };
 
 export type PublicButecoDetail = {
+  id: string;
   slug: string;
   nome: string;
   cidade: string;
@@ -40,6 +41,7 @@ type PublicButecoRecord = PublicButecoDetail & {
 
 const e2eFixtureButecos: PublicButecoRecord[] = [
   {
+    id: "fixture-bar-do-zeca",
     slug: "bar-do-zeca",
     nome: "Bar do Zeca",
     cidade: "Belo Horizonte",
@@ -54,6 +56,7 @@ const e2eFixtureButecos: PublicButecoRecord[] = [
     lng: -43.9342,
   },
   {
+    id: "fixture-cantin-do-joao",
     slug: "cantin-do-joao",
     nome: "Cantin do João",
     cidade: "Belo Horizonte",
@@ -68,6 +71,7 @@ const e2eFixtureButecos: PublicButecoRecord[] = [
     lng: -43.9386,
   },
   {
+    id: "fixture-esquina-da-celia",
     slug: "esquina-da-celia",
     nome: "Esquina da Célia",
     cidade: "Contagem",
@@ -255,6 +259,7 @@ export async function getButecoBySlug(slug: string): Promise<PublicButecoDetail 
     }
 
     return {
+      id: buteco.id,
       slug: buteco.slug,
       nome: buteco.nome,
       cidade: buteco.cidade,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     env: {
+      DATABASE_URL: "postgresql://fixture:fixture@127.0.0.1:5432/fixture?sslmode=disable",
       E2E_USE_FIXTURES: "true",
       GOOGLE_CLIENT_ID: "e2e-google-client-id",
       GOOGLE_CLIENT_SECRET: "e2e-google-client-secret",

--- a/docs/superpowers/plans/2026-04-23-issue-42-detail-actions.md
+++ b/docs/superpowers/plans/2026-04-23-issue-42-detail-actions.md
@@ -1,0 +1,64 @@
+# Issue #42 Detail Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add authenticated favorite/visit actions to the buteco detail page with a clear anonymous login CTA, deterministic fixture-mode auth for E2E, and coverage for critical states.
+
+**Architecture:** Keep the detail page as a Server Component that reads buteco data plus user-specific action state on the server. Render a focused client action panel for authenticated interaction and a link-based CTA for anonymous users. Extend fixture mode with a mocked session path so E2E can cover both anonymous and authenticated flows without depending on live NextAuth.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, NextAuth v5, Prisma, Jest, Testing Library, Playwright
+
+---
+
+### Task 1: Auth-Aware Detail Read Model
+
+**Files:**
+- Modify: `apps/web/lib/__tests__/public-butecos.test.ts`
+- Create: `apps/web/lib/__tests__/detail-actions.test.ts`
+- Modify: `apps/web/lib/public-butecos.ts`
+- Create: `apps/web/lib/detail-actions.ts`
+
+- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 2: Run the Jest targets and verify expected failures**
+- [ ] **Step 3: Implement the minimal session/state helper and detail read model**
+- [ ] **Step 4: Re-run the Jest targets and verify they pass**
+- [ ] **Step 5: Commit**
+
+### Task 2: Detail Page and Action Panel
+
+**Files:**
+- Create: `apps/web/components/butecos/buteco-action-panel.tsx`
+- Create: `apps/web/components/butecos/__tests__/buteco-action-panel.test.tsx`
+- Create: `apps/web/app/(public)/butecos/[slug]/__tests__/page.test.tsx`
+- Modify: `apps/web/app/(public)/butecos/[slug]/page.tsx`
+
+- [ ] **Step 1: Write the failing component and page tests**
+- [ ] **Step 2: Run the Jest targets and verify expected failures**
+- [ ] **Step 3: Implement the minimal authenticated and anonymous UI states**
+- [ ] **Step 4: Re-run the Jest targets and verify they pass**
+- [ ] **Step 5: Commit**
+
+### Task 3: Route Handler Validation for Detail Actions
+
+**Files:**
+- Modify: `apps/web/app/api/butecos/__tests__/route.test.ts`
+- Modify: `apps/web/app/api/butecos/route.ts`
+
+- [ ] **Step 1: Write the failing route tests for payload validation and detail-flow expectations**
+- [ ] **Step 2: Run the Jest target and verify expected failures**
+- [ ] **Step 3: Implement the minimal route changes**
+- [ ] **Step 4: Re-run the Jest target and verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 4: Deterministic E2E Coverage
+
+**Files:**
+- Modify: `apps/web/e2e/public-flows.spec.ts`
+- Modify: `apps/web/playwright.config.ts`
+- Modify: `apps/web/lib/detail-actions.ts`
+
+- [ ] **Step 1: Write the failing anonymous and mocked-authenticated detail E2E tests**
+- [ ] **Step 2: Run the Playwright targets and verify expected failures**
+- [ ] **Step 3: Implement the minimal fixture-mode mock session support**
+- [ ] **Step 4: Re-run the Playwright targets and verify they pass**
+- [ ] **Step 5: Commit**


### PR DESCRIPTION
﻿## O que mudou
- Adiciona painel de ações na página de detalhe para favoritar, desfavoritar e marcar visita.
- Mantém usuário anônimo em fluxo seguro com CTA de login.
- Adiciona caminho de fixture mode para E2E autenticado sem OAuth real.

## Validação
- `pnpm format:check`
- `pnpm lint`
- `pnpm test -- --runInBand`
- `pnpm test:e2e`

Closes #42
