### PR TITLE
feat: aplica tema inicial e geolocalização

### DIFF
--- a/apps/web/components/mapa/mapa-butecos.tsx
+++ b/apps/web/components/mapa/mapa-butecos.tsx
@@ -58,6 +58,12 @@ export function MapaButecos({ butecos }: Readonly<MapaButecosProps>) {
           {erro}
         </div>
       )}
+      {coords && !erro && (
+        <div className="flex items-center gap-2 border-b border-emerald-100 bg-emerald-50 px-4 py-2.5 text-sm text-emerald-700 dark:border-emerald-950 dark:bg-emerald-950/40 dark:text-emerald-300">
+          <span aria-hidden="true">📍</span>
+          Usando sua localização para destacar o mapa.
+        </div>
+      )}
       <div className="relative">
         <button
           onClick={buscar}
@@ -66,7 +72,7 @@ export function MapaButecos({ butecos }: Readonly<MapaButecosProps>) {
           className="absolute right-3 top-3 z-[1000] flex items-center gap-1.5 rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 shadow-md transition hover:bg-zinc-50 disabled:cursor-wait disabled:opacity-70 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
         >
           <span aria-hidden="true">{carregando ? "⏳" : "📍"}</span>
-          {carregando ? "Localizando…" : "Usar minha localização"}
+          {carregando ? "Localizando..." : "Usar minha localização"}
         </button>
         <MapContainer
           center={defaultCenter}

--- a/apps/web/components/ui/theme-toggle.tsx
+++ b/apps/web/components/ui/theme-toggle.tsx
@@ -1,18 +1,42 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
+import { resolveInitialTheme, type ThemePreference } from "@/lib/theme";
+
+function subscribeToThemeChanges(callback: () => void) {
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
+
+function getThemeSnapshot(): ThemePreference {
+  return resolveInitialTheme({
+    storedTheme: (localStorage.getItem("theme") as ThemePreference | null) ?? null,
+    systemPrefersDark: window.matchMedia("(prefers-color-scheme: dark)").matches,
+  });
+}
+
+function getServerThemeSnapshot(): ThemePreference {
+  return "light";
+}
 
 export function ThemeToggle() {
-  const [isDark, setIsDark] = useState(false);
+  const theme = useSyncExternalStore(
+    subscribeToThemeChanges,
+    getThemeSnapshot,
+    getServerThemeSnapshot
+  );
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [theme]);
 
   function toggle() {
-    const currentThemeIsDark = document.documentElement.classList.contains("dark");
-    const next = !currentThemeIsDark;
-    setIsDark(next);
-    document.documentElement.classList.toggle("dark", next);
+    const nextTheme: ThemePreference = theme === "dark" ? "light" : "dark";
+    document.documentElement.classList.toggle("dark", nextTheme === "dark");
 
     try {
-      localStorage.setItem("theme", next ? "dark" : "light");
+      localStorage.setItem("theme", nextTheme);
+      window.dispatchEvent(new StorageEvent("storage", { key: "theme", newValue: nextTheme }));
     } catch {}
   }
 
@@ -20,10 +44,10 @@ export function ThemeToggle() {
     <button
       type="button"
       onClick={toggle}
-      aria-label={isDark ? "Mudar para tema claro" : "Mudar para tema escuro"}
+      aria-label={theme === "dark" ? "Mudar para tema claro" : "Mudar para tema escuro"}
       className="rounded-full border border-zinc-200 p-2 text-zinc-600 transition hover:border-amber-300 hover:bg-amber-50 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-amber-600 dark:hover:bg-amber-900/20"
     >
-      {isDark ? (
+      {theme === "dark" ? (
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"

--- a/apps/web/components/ui/theme-toggle.tsx
+++ b/apps/web/components/ui/theme-toggle.tsx
@@ -5,7 +5,11 @@ import { resolveInitialTheme, type ThemePreference } from "@/lib/theme";
 
 function subscribeToThemeChanges(callback: () => void) {
   window.addEventListener("storage", callback);
-  return () => window.removeEventListener("storage", callback);
+  window.addEventListener("theme-changed", callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+    window.removeEventListener("theme-changed", callback);
+  };
 }
 
 function getThemeSnapshot(): ThemePreference {
@@ -36,7 +40,7 @@ export function ThemeToggle() {
 
     try {
       localStorage.setItem("theme", nextTheme);
-      window.dispatchEvent(new StorageEvent("storage", { key: "theme", newValue: nextTheme }));
+      window.dispatchEvent(new CustomEvent("theme-changed"));
     } catch {}
   }
 

--- a/apps/web/e2e/public-flows.spec.ts
+++ b/apps/web/e2e/public-flows.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("carrega a home pública com os elementos principais", async ({ page }) => {
+test("carrega a home publica com os elementos principais", async ({ page }) => {
   await page.goto("/");
 
   await expect(
@@ -60,7 +60,7 @@ test("busca por nome do buteco ou petisco", async ({ page }) => {
   await expect(page.getByRole("link", { name: /Bar do Zeca/i })).toHaveCount(0);
 });
 
-test("exibe estado vazio quando não há resultados", async ({ page }) => {
+test("exibe estado vazio quando nao ha resultados", async ({ page }) => {
   await page.goto("/butecos");
 
   await page.locator('input[name="q"]').fill("Inexistente");
@@ -72,7 +72,7 @@ test("exibe estado vazio quando não há resultados", async ({ page }) => {
   await expect(page.getByRole("link", { name: "Voltar para a home" })).toBeVisible();
 });
 
-test("navega da listagem para a página de detalhe", async ({ page }) => {
+test("navega da listagem para a pagina de detalhe", async ({ page }) => {
   await page.goto("/butecos");
 
   await page.getByRole("link", { name: /Bar do Zeca/i }).click();
@@ -81,7 +81,7 @@ test("navega da listagem para a página de detalhe", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Bar do Zeca" })).toBeVisible();
 });
 
-test("renderiza os dados principais da página de detalhe", async ({ page }) => {
+test("renderiza os dados principais da pagina de detalhe", async ({ page }) => {
   await page.goto("/butecos/bar-do-zeca");
 
   await expect(page.getByRole("heading", { name: "Bar do Zeca" })).toBeVisible();
@@ -89,4 +89,34 @@ test("renderiza os dados principais da página de detalhe", async ({ page }) => 
   await expect(page.getByRole("heading", { name: "Bolinho da Casa" })).toBeVisible();
   await expect(page.getByText("Rua dos Testes, 123 - Savassi, Belo Horizonte - MG")).toBeVisible();
   await expect(page.getByText("(31) 3333-1111")).toBeVisible();
+});
+
+test("aplica o tema escuro inicial a partir da preferencia salva", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("theme", "dark");
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await expect(page.getByRole("button", { name: "Mudar para tema claro" })).toBeVisible();
+});
+
+test("exibe feedback claro quando a localizacao esta indisponivel no primeiro acesso", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  await page.goto("/");
+
+  await expect(page.getByText("Geolocalização não é suportada pelo seu navegador.")).toBeVisible();
 });

--- a/apps/web/lib/__tests__/geolocalizacao.test.ts
+++ b/apps/web/lib/__tests__/geolocalizacao.test.ts
@@ -1,0 +1,51 @@
+import { resolveGeolocationStartup } from "@/lib/geolocalizacao";
+
+describe("resolveGeolocationStartup", () => {
+  it("requests the current position immediately when permission is granted", () => {
+    expect(
+      resolveGeolocationStartup({
+        geolocationSupported: true,
+        permissionState: "granted",
+      })
+    ).toEqual({
+      shouldRequestLocation: true,
+      errorMessage: null,
+    });
+  });
+
+  it("requests the current position when the browser still needs to prompt the user", () => {
+    expect(
+      resolveGeolocationStartup({
+        geolocationSupported: true,
+        permissionState: "prompt",
+      })
+    ).toEqual({
+      shouldRequestLocation: true,
+      errorMessage: null,
+    });
+  });
+
+  it("keeps the site usable and returns a clear message when permission is denied", () => {
+    expect(
+      resolveGeolocationStartup({
+        geolocationSupported: true,
+        permissionState: "denied",
+      })
+    ).toEqual({
+      shouldRequestLocation: false,
+      errorMessage: "Localização indisponível. Você ainda pode explorar o mapa manualmente.",
+    });
+  });
+
+  it("keeps the site usable when geolocation is unavailable", () => {
+    expect(
+      resolveGeolocationStartup({
+        geolocationSupported: false,
+        permissionState: null,
+      })
+    ).toEqual({
+      shouldRequestLocation: false,
+      errorMessage: "Geolocalização não é suportada pelo seu navegador.",
+    });
+  });
+});

--- a/apps/web/lib/__tests__/theme.test.ts
+++ b/apps/web/lib/__tests__/theme.test.ts
@@ -1,0 +1,28 @@
+import { resolveInitialTheme } from "@/lib/theme";
+
+describe("resolveInitialTheme", () => {
+  it("prioritizes a persisted dark preference over a light system preference", () => {
+    expect(
+      resolveInitialTheme({
+        storedTheme: "dark",
+        systemPrefersDark: false,
+      })
+    ).toBe("dark");
+  });
+
+  it("falls back to the system preference when there is no persisted theme", () => {
+    expect(
+      resolveInitialTheme({
+        storedTheme: null,
+        systemPrefersDark: true,
+      })
+    ).toBe("dark");
+
+    expect(
+      resolveInitialTheme({
+        storedTheme: null,
+        systemPrefersDark: false,
+      })
+    ).toBe("light");
+  });
+});

--- a/apps/web/lib/__tests__/use-geolocalizacao.test.ts
+++ b/apps/web/lib/__tests__/use-geolocalizacao.test.ts
@@ -1,0 +1,145 @@
+/** @jest-environment jsdom */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useGeolocalizacao } from "@/lib/use-geolocalizacao";
+
+const originalGeolocation = navigator.geolocation;
+const originalPermissions = navigator.permissions;
+
+function setNavigatorProperty<K extends keyof Navigator>(key: K, value: Navigator[K] | undefined) {
+  Object.defineProperty(navigator, key, {
+    configurable: true,
+    value,
+  });
+}
+
+function makePosition(latitude: number, longitude: number): GeolocationPosition {
+  return {
+    coords: {
+      accuracy: 1,
+      altitude: null,
+      altitudeAccuracy: null,
+      heading: null,
+      latitude,
+      longitude,
+      speed: null,
+    },
+    timestamp: Date.now(),
+  };
+}
+
+function makePositionError(code: number): GeolocationPositionError {
+  return {
+    code,
+    message: "Erro de geolocalizacao",
+    PERMISSION_DENIED: 1,
+    POSITION_UNAVAILABLE: 2,
+    TIMEOUT: 3,
+  };
+}
+
+function mockPermissions(state: PermissionState) {
+  const query = jest.fn<ReturnType<Permissions["query"]>, Parameters<Permissions["query"]>>(() =>
+    Promise.resolve({ state } as PermissionStatus)
+  );
+
+  setNavigatorProperty("permissions", { query } as Permissions);
+
+  return query;
+}
+
+function mockGeolocation() {
+  const getCurrentPosition = jest.fn<
+    ReturnType<Geolocation["getCurrentPosition"]>,
+    Parameters<Geolocation["getCurrentPosition"]>
+  >();
+  const watchPosition = jest.fn<
+    ReturnType<Geolocation["watchPosition"]>,
+    Parameters<Geolocation["watchPosition"]>
+  >(() => 1);
+  const clearWatch = jest.fn<
+    ReturnType<Geolocation["clearWatch"]>,
+    Parameters<Geolocation["clearWatch"]>
+  >();
+
+  setNavigatorProperty("geolocation", {
+    clearWatch,
+    getCurrentPosition,
+    watchPosition,
+  } as Geolocation);
+
+  return getCurrentPosition;
+}
+
+describe("useGeolocalizacao", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    setNavigatorProperty("geolocation", originalGeolocation);
+    setNavigatorProperty("permissions", originalPermissions);
+  });
+
+  it("requests the position on startup when permission is prompt and stores coordinates", async () => {
+    const getCurrentPosition = mockGeolocation();
+    mockPermissions("prompt");
+
+    getCurrentPosition.mockImplementation((onSuccess) => {
+      onSuccess(makePosition(-19.93, -43.94));
+    });
+
+    const { result } = renderHook(() => useGeolocalizacao());
+
+    await waitFor(() => expect(result.current.coords).toEqual({ lat: -19.93, lng: -43.94 }));
+    expect(result.current.erro).toBeNull();
+    expect(result.current.carregando).toBe(false);
+  });
+
+  it("shows a startup message when geolocation is unsupported", async () => {
+    setNavigatorProperty("geolocation", undefined);
+    setNavigatorProperty("permissions", undefined);
+
+    const { result } = renderHook(() => useGeolocalizacao());
+
+    await waitFor(() =>
+      expect(result.current.erro).toBe(
+        "Geolocaliza\u00e7\u00e3o n\u00e3o \u00e9 suportada pelo seu navegador."
+      )
+    );
+  });
+
+  it("does not request the position when permission is denied", async () => {
+    const getCurrentPosition = mockGeolocation();
+    mockPermissions("denied");
+
+    const { result } = renderHook(() => useGeolocalizacao());
+
+    await waitFor(() =>
+      expect(result.current.erro).toBe(
+        "Localiza\u00e7\u00e3o indispon\u00edvel. Voc\u00ea ainda pode explorar o mapa manualmente."
+      )
+    );
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+  });
+
+  it("maps manual lookup failures to a clear error message", async () => {
+    const getCurrentPosition = mockGeolocation();
+    mockPermissions("denied");
+
+    getCurrentPosition.mockImplementation((_onSuccess, onError) => {
+      onError?.(makePositionError(3));
+    });
+
+    const { result } = renderHook(() => useGeolocalizacao());
+
+    await waitFor(() => expect(result.current.erro).not.toBeNull());
+
+    act(() => {
+      result.current.buscar();
+    });
+
+    await waitFor(() =>
+      expect(result.current.erro).toBe(
+        "Tempo esgotado ao obter localiza\u00e7\u00e3o. Tente novamente."
+      )
+    );
+  });
+});

--- a/apps/web/lib/geolocalizacao.ts
+++ b/apps/web/lib/geolocalizacao.ts
@@ -1,0 +1,25 @@
+export type GeolocationPermissionState = PermissionState | null;
+
+export function resolveGeolocationStartup(input: {
+  geolocationSupported: boolean;
+  permissionState: GeolocationPermissionState;
+}) {
+  if (!input.geolocationSupported) {
+    return {
+      shouldRequestLocation: false,
+      errorMessage: "Geolocalização não é suportada pelo seu navegador.",
+    };
+  }
+
+  if (input.permissionState === "denied") {
+    return {
+      shouldRequestLocation: false,
+      errorMessage: "Localização indisponível. Você ainda pode explorar o mapa manualmente.",
+    };
+  }
+
+  return {
+    shouldRequestLocation: true,
+    errorMessage: null,
+  };
+}

--- a/apps/web/lib/theme.ts
+++ b/apps/web/lib/theme.ts
@@ -1,0 +1,12 @@
+export type ThemePreference = "dark" | "light";
+
+export function resolveInitialTheme(input: {
+  storedTheme: ThemePreference | null;
+  systemPrefersDark: boolean;
+}): ThemePreference {
+  if (input.storedTheme) {
+    return input.storedTheme;
+  }
+
+  return input.systemPrefersDark ? "dark" : "light";
+}

--- a/apps/web/lib/use-geolocalizacao.ts
+++ b/apps/web/lib/use-geolocalizacao.ts
@@ -38,14 +38,12 @@ function resolveFallbackDecision(geolocationSupported: boolean): GeolocationDeci
 }
 
 async function resolveStartupDecision(geolocationSupported: boolean): Promise<GeolocationDecision> {
-  const permissionsApi = navigator.permissions?.query;
-
-  if (!permissionsApi) {
+  if (!navigator.permissions?.query) {
     return resolveFallbackDecision(geolocationSupported);
   }
 
   try {
-    const permission = await permissionsApi({ name: "geolocation" });
+    const permission = await navigator.permissions.query({ name: "geolocation" });
 
     return resolveGeolocationStartup({
       geolocationSupported,

--- a/apps/web/lib/use-geolocalizacao.ts
+++ b/apps/web/lib/use-geolocalizacao.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { resolveGeolocationStartup } from "@/lib/geolocalizacao";
 
 type Coordenadas = { lat: number; lng: number };
 
@@ -48,6 +49,54 @@ export function useGeolocalizacao(): GeolocalizacaoState {
       { timeout: 10000, maximumAge: 60000 }
     );
   }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    async function startup() {
+      const geolocationSupported = typeof navigator !== "undefined" && "geolocation" in navigator;
+      const permissionsApi = navigator.permissions?.query;
+
+      if (!permissionsApi) {
+        const fallback = resolveGeolocationStartup({
+          geolocationSupported,
+          permissionState: geolocationSupported ? "prompt" : null,
+        });
+
+        if (!active) return;
+        if (fallback.errorMessage) setErro(fallback.errorMessage);
+        if (fallback.shouldRequestLocation) buscar();
+        return;
+      }
+
+      try {
+        const permission = await permissionsApi({ name: "geolocation" });
+        if (!active) return;
+
+        const decision = resolveGeolocationStartup({
+          geolocationSupported,
+          permissionState: permission.state,
+        });
+
+        if (decision.errorMessage) setErro(decision.errorMessage);
+        if (decision.shouldRequestLocation) buscar();
+      } catch {
+        if (!active) return;
+        const fallback = resolveGeolocationStartup({
+          geolocationSupported,
+          permissionState: geolocationSupported ? "prompt" : null,
+        });
+        if (fallback.errorMessage) setErro(fallback.errorMessage);
+        if (fallback.shouldRequestLocation) buscar();
+      }
+    }
+
+    void startup();
+
+    return () => {
+      active = false;
+    };
+  }, [buscar]);
 
   return { coords, carregando, erro, buscar };
 }

--- a/apps/web/lib/use-geolocalizacao.ts
+++ b/apps/web/lib/use-geolocalizacao.ts
@@ -12,6 +12,50 @@ type GeolocalizacaoState = {
   buscar: () => void;
 };
 
+type GeolocationDecision = ReturnType<typeof resolveGeolocationStartup>;
+
+function getPositionErrorMessage(error: GeolocationPositionError): string {
+  if (error.code === error.PERMISSION_DENIED) {
+    return "Permiss\u00e3o negada. Verifique as configura\u00e7\u00f5es do seu navegador.";
+  }
+
+  if (error.code === error.POSITION_UNAVAILABLE) {
+    return "Localiza\u00e7\u00e3o indispon\u00edvel. Verifique se o GPS est\u00e1 ativado.";
+  }
+
+  if (error.code === error.TIMEOUT) {
+    return "Tempo esgotado ao obter localiza\u00e7\u00e3o. Tente novamente.";
+  }
+
+  return "N\u00e3o foi poss\u00edvel obter sua localiza\u00e7\u00e3o.";
+}
+
+function resolveFallbackDecision(geolocationSupported: boolean): GeolocationDecision {
+  return resolveGeolocationStartup({
+    geolocationSupported,
+    permissionState: geolocationSupported ? "prompt" : null,
+  });
+}
+
+async function resolveStartupDecision(geolocationSupported: boolean): Promise<GeolocationDecision> {
+  const permissionsApi = navigator.permissions?.query;
+
+  if (!permissionsApi) {
+    return resolveFallbackDecision(geolocationSupported);
+  }
+
+  try {
+    const permission = await permissionsApi({ name: "geolocation" });
+
+    return resolveGeolocationStartup({
+      geolocationSupported,
+      permissionState: permission.state,
+    });
+  } catch {
+    return resolveFallbackDecision(geolocationSupported);
+  }
+}
+
 export function useGeolocalizacao(): GeolocalizacaoState {
   const [coords, setCoords] = useState<Coordenadas | null>(null);
   const [carregando, setCarregando] = useState(false);
@@ -19,7 +63,7 @@ export function useGeolocalizacao(): GeolocalizacaoState {
 
   const buscar = useCallback(() => {
     if (!navigator.geolocation) {
-      setErro("Geolocalização não é suportada pelo seu navegador.");
+      setErro("Geolocaliza\u00e7\u00e3o n\u00e3o \u00e9 suportada pelo seu navegador.");
       return;
     }
 
@@ -35,15 +79,7 @@ export function useGeolocalizacao(): GeolocalizacaoState {
         setCarregando(false);
       },
       (error) => {
-        if (error.code === error.PERMISSION_DENIED) {
-          setErro("Permissão negada. Verifique as configurações do seu navegador.");
-        } else if (error.code === error.POSITION_UNAVAILABLE) {
-          setErro("Localização indisponível. Verifique se o GPS está ativado.");
-        } else if (error.code === error.TIMEOUT) {
-          setErro("Tempo esgotado ao obter localização. Tente novamente.");
-        } else {
-          setErro("Não foi possível obter sua localização.");
-        }
+        setErro(getPositionErrorMessage(error));
         setCarregando(false);
       },
       { timeout: 10000, maximumAge: 60000 }
@@ -55,40 +91,11 @@ export function useGeolocalizacao(): GeolocalizacaoState {
 
     async function startup() {
       const geolocationSupported = typeof navigator !== "undefined" && "geolocation" in navigator;
-      const permissionsApi = navigator.permissions?.query;
+      const decision = await resolveStartupDecision(geolocationSupported);
 
-      if (!permissionsApi) {
-        const fallback = resolveGeolocationStartup({
-          geolocationSupported,
-          permissionState: geolocationSupported ? "prompt" : null,
-        });
-
-        if (!active) return;
-        if (fallback.errorMessage) setErro(fallback.errorMessage);
-        if (fallback.shouldRequestLocation) buscar();
-        return;
-      }
-
-      try {
-        const permission = await permissionsApi({ name: "geolocation" });
-        if (!active) return;
-
-        const decision = resolveGeolocationStartup({
-          geolocationSupported,
-          permissionState: permission.state,
-        });
-
-        if (decision.errorMessage) setErro(decision.errorMessage);
-        if (decision.shouldRequestLocation) buscar();
-      } catch {
-        if (!active) return;
-        const fallback = resolveGeolocationStartup({
-          geolocationSupported,
-          permissionState: geolocationSupported ? "prompt" : null,
-        });
-        if (fallback.errorMessage) setErro(fallback.errorMessage);
-        if (fallback.shouldRequestLocation) buscar();
-      }
+      if (!active) return;
+      if (decision.errorMessage) setErro(decision.errorMessage);
+      if (decision.shouldRequestLocation) buscar();
     }
 
     void startup();

--- a/apps/web/lib/use-geolocalizacao.ts
+++ b/apps/web/lib/use-geolocalizacao.ts
@@ -88,7 +88,7 @@ export function useGeolocalizacao(): GeolocalizacaoState {
     let active = true;
 
     async function startup() {
-      const geolocationSupported = typeof navigator !== "undefined" && "geolocation" in navigator;
+      const geolocationSupported = "geolocation" in navigator;
       const decision = await resolveStartupDecision(geolocationSupported);
 
       if (!active) return;


### PR DESCRIPTION
﻿## O que mudou
- Define tema inicial a partir de preferência salva ou preferência do sistema.
- Aplica o tema sem mismatch de hidratação no toggle.
- Verifica geolocalização no primeiro acesso e exibe feedback claro quando indisponível.

## Validação
- `pnpm format:check`
- `pnpm lint`
- `pnpm test -- --runInBand`
- `pnpm test:e2e`

Closes #70
Closes #71
