### PR TITLE
feat(ds-4): redesign home + listagem de botecos

### DIFF
--- a/apps/web/app/(public)/butecos/page.tsx
+++ b/apps/web/app/(public)/butecos/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Suspense } from "react";
 import { ButecosFilterForm } from "@/components/butecos/filter-form";
+import { ButecoCard } from "@/components/butecos/buteco-card";
 import { countActiveButecoFilters, normalizeButecoFilters } from "@/lib/buteco-filters";
 import { getButecosPageData } from "@/lib/public-butecos";
 
@@ -21,58 +22,58 @@ export default async function ButecosPage({
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6">
-      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
+      <section className="rounded-3xl border border-line-soft bg-surface p-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400">
+            <p className="font-mono text-[11px] uppercase tracking-wide text-ink-muted">
               Explorar botecos
             </p>
-            <h1 className="mt-1 text-3xl font-black tracking-tight text-zinc-900 dark:text-zinc-50">
+            <h1 className="mt-1 font-display text-[32px] font-bold tracking-tight text-ink">
               Botecos
             </h1>
-            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-zinc-600 dark:text-zinc-400 sm:text-base">
+            <p className="mt-2 max-w-2xl font-body text-[14px] leading-relaxed text-ink-soft sm:text-[15px]">
               Refine a lista por cidade, bairro ou busca textual para encontrar um petisco ou boteco
               com mais rapidez.
             </p>
           </div>
 
-          <div className="inline-flex items-center rounded-full bg-zinc-100 px-4 py-2 text-sm font-semibold text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+          <div className="inline-flex items-center rounded-full bg-surface-alt px-4 py-2 font-mono text-[11px] uppercase tracking-wide text-ink-muted">
             {butecos.length} resultado{butecos.length === 1 ? "" : "s"}
             {activeFiltersLabel}
           </div>
         </div>
       </section>
 
-      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
+      <section className="rounded-3xl border border-line-soft bg-surface p-6">
         <Suspense>
           <ButecosFilterForm cidadeOptions={cidadeOptions} bairroOptions={bairroOptions} />
         </Suspense>
 
         {filters.cidade && bairroOptions.length === 0 ? (
-          <p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+          <p className="mt-4 font-body text-[14px] text-ink-muted">
             Ainda não existem bairros cadastrados para a cidade selecionada.
           </p>
         ) : null}
       </section>
 
       {butecos.length === 0 ? (
-        <section className="rounded-3xl border border-dashed border-zinc-300 bg-zinc-50 px-6 py-12 text-center dark:border-zinc-700 dark:bg-zinc-900/50">
-          <h2 className="text-xl font-bold text-zinc-900 dark:text-zinc-50">
-            Nenhum boteco encontrado
+        <section className="rounded-3xl border border-dashed border-line bg-surface-alt px-6 py-12 text-center">
+          <h2 className="font-display text-[22px] font-bold text-ink">
+            Nenhum buteco encontrado por aqui
           </h2>
-          <p className="mt-2 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
-            Tente ajustar os filtros ou limpar a busca para ver mais participantes.
+          <p className="mt-2 font-body text-[14px] leading-relaxed text-ink-soft">
+            Tente outro bairro ou limpa os filtros.
           </p>
           <div className="mt-5 flex flex-col justify-center gap-3 sm:flex-row">
             <Link
               href="/butecos"
-              className="rounded-full bg-amber-500 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-amber-600"
+              className="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2.5 font-body text-[13px] font-medium text-primary-ink transition hover:bg-terracota-600"
             >
               Limpar filtros
             </Link>
             <Link
               href="/"
-              className="rounded-full border border-zinc-200 px-5 py-2.5 text-sm font-semibold text-zinc-700 transition hover:border-amber-300 hover:bg-amber-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-amber-600 dark:hover:bg-amber-900/20"
+              className="inline-flex items-center justify-center rounded-full border border-tinto-700 px-5 py-2.5 font-body text-[13px] font-medium text-tinto-700 transition hover:bg-terracota-100"
             >
               Voltar para a home
             </Link>
@@ -82,25 +83,7 @@ export default async function ButecosPage({
         <ul className="grid gap-4 sm:grid-cols-2">
           {butecos.map((b) => (
             <li key={b.slug}>
-              <Link
-                href={`/butecos/${b.slug}`}
-                className="block rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-amber-400 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-amber-500"
-              >
-                <p className="text-lg font-bold text-zinc-900 dark:text-zinc-50">{b.nome}</p>
-                <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-                  {b.bairro ? `${b.bairro}, ` : ""}
-                  {b.cidade}
-                </p>
-                {b.petiscoNome ? (
-                  <p className="mt-3 text-sm font-medium text-amber-700 dark:text-amber-400">
-                    {b.petiscoNome}
-                  </p>
-                ) : (
-                  <p className="mt-3 text-sm text-zinc-400 dark:text-zinc-500">
-                    Petisco ainda não informado
-                  </p>
-                )}
-              </Link>
+              <ButecoCard buteco={b} />
             </li>
           ))}
         </ul>

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { MapaButecosShell } from "@/components/mapa/mapa-butecos-shell";
 import { getHomeData } from "@/lib/public-butecos";
 
@@ -11,17 +12,30 @@ export default async function Home() {
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-5 sm:gap-8 sm:px-6 sm:py-8 lg:px-8">
-      <section className="rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-700 dark:bg-zinc-900 sm:p-7">
-        <h1 className="text-3xl font-black leading-tight tracking-tight text-zinc-900 dark:text-zinc-50 sm:text-4xl">
-          Descubra os botecos no mapa
-        </h1>
-        <p className="mt-3 max-w-2xl text-base leading-relaxed text-zinc-600 dark:text-zinc-400 sm:text-lg">
-          Explore os participantes do Comida di Buteco, filtre por região e encontre seu próximo
-          destino.
-        </p>
+      <section className="relative overflow-hidden rounded-3xl bg-surface p-5 sm:p-7">
+        <div className="grao absolute inset-0" aria-hidden />
+        <div className="relative">
+          <h1 className="font-display text-[42px] font-bold leading-tight tracking-tight text-tinto-700 sm:text-[52px]">
+            Descubra os botecos no mapa
+          </h1>
+          <p className="mt-3 max-w-2xl font-body text-[15px] leading-relaxed text-ink-soft sm:text-[17px]">
+            Explore os participantes do Comida di Buteco, filtre por região e encontre seu próximo
+            destino.
+          </p>
 
-        <div className="mt-5 inline-flex items-center rounded-full bg-amber-100 px-4 py-2 text-sm font-bold text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
-          {total > 0 ? `${total} botecos participando` : "Em breve: botecos participantes no mapa"}
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            {total > 0 && (
+              <span className="inline-flex items-center rounded-full bg-mostarda-100 px-4 py-2 font-mono text-[12px] font-bold text-mostarda-700">
+                {total} botecos participando
+              </span>
+            )}
+            <Link
+              href="/butecos"
+              className="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2.5 font-body text-[14px] font-medium text-primary-ink transition hover:bg-terracota-600"
+            >
+              Ver botecos
+            </Link>
+          </div>
         </div>
       </section>
 

--- a/apps/web/lib/__tests__/public-butecos.test.ts
+++ b/apps/web/lib/__tests__/public-butecos.test.ts
@@ -76,6 +76,7 @@ describe("public-butecos fixtures", () => {
         cidade: "Belo Horizonte",
         bairro: "Savassi",
         petiscoNome: "Bolinho da Casa",
+        fotoUrl: null,
       },
     ]);
   });

--- a/apps/web/lib/public-butecos.ts
+++ b/apps/web/lib/public-butecos.ts
@@ -10,6 +10,7 @@ export type PublicButecoListItem = {
   cidade: string;
   bairro: string | null;
   petiscoNome: string | null;
+  fotoUrl: string | null;
 };
 
 export type PublicButecoMapItem = {
@@ -201,13 +202,14 @@ export async function getButecosPageData(filters: ButecoSearchFilters) {
       cidades,
       bairros,
       butecos: filteredButecos.map(
-        ({ slug, nome, cidade, bairro, petiscoNome }) =>
+        ({ slug, nome, cidade, bairro, petiscoNome, fotoUrl }) =>
           ({
             slug,
             nome,
             cidade,
             bairro,
             petiscoNome,
+            fotoUrl,
           }) satisfies PublicButecoListItem
       ),
     };
@@ -240,6 +242,7 @@ export async function getButecosPageData(filters: ButecoSearchFilters) {
         cidade: true,
         bairro: true,
         petiscoNome: true,
+        fotoUrl: true,
       },
     }),
   ]);


### PR DESCRIPTION
## Resumo

- Adiciona `fotoUrl` ao tipo `PublicButecoListItem`, ao select Prisma e ao fixture E2E — necessário para ButecoCard auto-resolver variante photo/flat
- Redesenha Home: hero com .grao overlay, h1 tinto-700 font-display, badge de contagem em mostarda-100 font-mono, CTA terracota
- Redesenha Listagem: grid usa ButecoCard (foto/flat por fotoUrl); cabeçalho font-display/ink; estado vazio com copy botequeiro; remove zinc/slate/amber

## Plano de testes

- [ ] `npm run test` — 92 testes passando (fixture atualizado com fotoUrl: null)
- [ ] `npm run lint` — sem erros
- [ ] `npm run build` — build OK

Closes #92
Refs #88