### PR TITLE
feat(ds-6): atualiza Login e redesenha Minha Conta

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -3,26 +3,26 @@ import { signIn } from "@/lib/auth";
 const loginBenefits = [
   {
     title: "Favoritos",
-    description: "Guarde os butecos que entraram na sua lista.",
+    description: "Salve os butecos que entraram no seu rolê.",
   },
   {
-    title: "Visitas",
-    description: "Registre os lugares que voce ja conheceu.",
+    title: "Carimbos",
+    description: "Colecione os lugares que você já conheceu.",
   },
 ] as const;
 
 const loginSupportCards = [
   {
     title: "Roteiro salvo",
-    description: "Retome sua selecao de bares sem comecar do zero.",
+    description: "Retome sua seleção sem começar do zero.",
   },
   {
-    title: "Conta util",
-    description: "O login existe para organizar sua experiencia, nao para atrapalhar.",
+    title: "Sem senha",
+    description: "Login simples com Google, sem burocracia.",
   },
   {
     title: "Pronto para mobile",
-    description: "A estrutura centralizada funciona bem em telas menores.",
+    description: "Acesse seu mapa de botecos de qualquer lugar.",
   },
 ] as const;
 
@@ -34,36 +34,35 @@ export default function LoginPage() {
       <div className="relative mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-3xl items-center justify-center">
         <div className="w-full rounded-[2.5rem] border border-white/10 bg-white/5 shadow-[0_28px_90px_rgba(14,8,5,0.42)] backdrop-blur-xl">
           <section className="px-6 pb-4 pt-8 text-center sm:px-8 sm:pt-10">
-            <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-4 py-2 text-[11px] font-bold uppercase tracking-[0.18em] text-amber-100/90">
+            <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-4 py-2 font-mono text-[11px] font-bold uppercase tracking-[0.18em] text-amber-100/90">
               Conta Onde Tem Buteco
             </span>
 
-            <h1 className="mx-auto mt-5 max-w-[12ch] text-4xl font-black leading-[0.95] tracking-[-0.04em] text-amber-50 sm:text-5xl">
-              Entre e continue seu mapa de botecos.
+            <h1 className="mx-auto mt-5 max-w-[12ch] font-display text-4xl font-black leading-[0.95] tracking-[-0.04em] text-amber-50 sm:text-5xl">
+              Entre e continue o rolê.
             </h1>
 
-            <p className="mx-auto mt-4 max-w-2xl text-sm leading-7 text-amber-50/85 sm:text-base">
-              Salve favoritos, acompanhe visitas e deixe seu proximo roteiro pronto para quando
-              bater a vontade de sair.
+            <p className="mx-auto mt-4 max-w-2xl font-body text-sm leading-7 text-amber-50/85 sm:text-base">
+              Salve seus butecos favoritos e colecione carimbos dos lugares que você conheceu.
             </p>
           </section>
 
           <section className="px-3 pb-3 sm:px-4">
             <div className="mx-auto w-full max-w-[29rem] rounded-[2rem] bg-[#fff8f1]/95 p-6 text-zinc-950 shadow-[0_26px_60px_rgba(20,11,7,0.24)] sm:p-8">
-              <div className="mx-auto grid h-16 w-16 place-items-center rounded-[1.4rem] bg-[linear-gradient(135deg,#fbbf24,#f97316)] text-lg font-black tracking-[-0.04em] text-[#361708]">
-                OTB
+              <div className="mx-auto grid h-16 w-16 place-items-center rounded-[1.4rem] bg-[linear-gradient(135deg,#fbbf24,#f97316)]">
+                <img src="/logo-mark.svg" alt="OTB" className="h-10 w-10" />
               </div>
 
-              <div className="mt-5 text-center text-[11px] font-extrabold uppercase tracking-[0.18em] text-[#ad5317]">
+              <div className="mt-5 text-center font-mono text-[11px] font-extrabold uppercase tracking-[0.18em] text-[#ad5317]">
                 Entrar
               </div>
 
-              <h2 className="mt-3 text-center text-3xl font-black leading-none tracking-[-0.04em] text-[#2c1409]">
+              <h2 className="mt-3 text-center font-display text-3xl font-black leading-none tracking-[-0.04em] text-[#2c1409]">
                 Acesse sua conta
               </h2>
 
-              <p className="mx-auto mt-3 max-w-[34ch] text-center text-sm leading-6 text-[#7b5036] sm:text-[0.95rem]">
-                Use o Google para sincronizar seu historico e manter seus butecos sempre por perto.
+              <p className="mx-auto mt-3 max-w-[34ch] text-center font-body text-sm leading-6 text-[#7b5036] sm:text-[0.95rem]">
+                Use o Google para sincronizar seu histórico e manter seus botecos sempre por perto.
               </p>
 
               <div className="mt-6 grid gap-3 sm:grid-cols-2">
@@ -72,8 +71,10 @@ export default function LoginPage() {
                     key={item.title}
                     className="rounded-[1.25rem] border border-[#f1d7c0] bg-[#fffdf9] p-4 text-left"
                   >
-                    <h3 className="text-sm font-bold text-[#2c1409]">{item.title}</h3>
-                    <p className="mt-2 text-sm leading-6 text-[#7b5036]">{item.description}</p>
+                    <h3 className="font-display text-sm font-bold text-[#2c1409]">{item.title}</h3>
+                    <p className="mt-2 font-body text-sm leading-6 text-[#7b5036]">
+                      {item.description}
+                    </p>
                   </div>
                 ))}
               </div>
@@ -87,16 +88,16 @@ export default function LoginPage() {
               >
                 <button
                   type="submit"
-                  className="inline-flex h-14 w-full items-center justify-center gap-3 rounded-full bg-[linear-gradient(135deg,#f59e0b,#f97316)] px-6 text-base font-extrabold text-[#2d1408] shadow-[0_18px_30px_rgba(245,158,11,0.28)] transition-transform duration-150 hover:scale-[1.01] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-700 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fff8f1]"
+                  className="inline-flex h-14 w-full items-center justify-center gap-3 rounded-full bg-[linear-gradient(135deg,#f59e0b,#f97316)] px-6 font-body text-base font-extrabold text-[#2d1408] shadow-[0_18px_30px_rgba(245,158,11,0.28)] transition-transform duration-150 hover:scale-[1.01] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-700 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fff8f1]"
                 >
-                  <span className="grid h-6 w-6 place-items-center rounded-full bg-white/90 text-xs font-black text-[#341708]">
+                  <span className="grid h-6 w-6 place-items-center rounded-full bg-white/90 font-mono text-xs font-black text-[#341708]">
                     G
                   </span>
                   Entrar com Google
                 </button>
               </form>
 
-              <p className="mt-4 text-center text-sm text-[#8d6042]">
+              <p className="mt-4 text-center font-body text-sm text-[#8d6042]">
                 Login simples, sem senha para criar.
               </p>
             </div>
@@ -108,8 +109,10 @@ export default function LoginPage() {
                 key={item.title}
                 className="rounded-[1.4rem] border border-white/10 bg-white/10 p-4"
               >
-                <h3 className="text-sm font-bold text-amber-50">{item.title}</h3>
-                <p className="mt-2 text-sm leading-6 text-amber-50/80">{item.description}</p>
+                <h3 className="font-display text-sm font-bold text-amber-50">{item.title}</h3>
+                <p className="mt-2 font-body text-sm leading-6 text-amber-50/80">
+                  {item.description}
+                </p>
               </div>
             ))}
           </section>

--- a/apps/web/app/(private)/minha-conta/page.tsx
+++ b/apps/web/app/(private)/minha-conta/page.tsx
@@ -1,6 +1,8 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { Carimbo } from "@/components/ui/carimbo";
 
 export default async function MinhaContaPage() {
   const session = await auth();
@@ -17,26 +19,42 @@ export default async function MinhaContaPage() {
   if (!user) redirect("/login");
 
   return (
-    <main className="max-w-2xl mx-auto px-4 py-8 space-y-10">
-      <h1 className="text-3xl font-bold dark:text-zinc-50">Minha Conta</h1>
+    <main className="mx-auto max-w-2xl space-y-10 px-4 py-8">
+      <h1 className="font-display text-[28px] font-bold text-ink">Minha Conta</h1>
 
       <section>
-        <h2 className="text-xl font-semibold mb-4 dark:text-zinc-100">Favoritos</h2>
+        <h2 className="mb-4 font-display text-[20px] font-semibold text-ink">Favoritos</h2>
         {user.favoritos.length === 0 ? (
-          <p className="text-zinc-500 dark:text-zinc-400">Nenhum favorito ainda.</p>
+          <div className="text-center">
+            <p className="font-body text-[14px] text-ink-muted">
+              Nenhum favorito ainda — bora explorar?
+            </p>
+            <Link
+              href="/butecos"
+              className="mt-4 inline-flex items-center justify-center rounded-full bg-primary px-5 py-2.5 font-body text-[13px] font-medium text-primary-ink transition hover:bg-terracota-600"
+            >
+              Ver botecos
+            </Link>
+          </div>
         ) : (
-          <ul className="space-y-2">
+          <ul className="space-y-3">
             {user.favoritos.map(({ buteco }) => (
-              <li key={buteco.slug}>
-                <a
-                  href={`/butecos/${buteco.slug}`}
-                  className="font-medium hover:underline dark:text-zinc-200"
-                >
-                  {buteco.nome}
-                </a>
-                <span className="text-zinc-500 text-sm ml-2 dark:text-zinc-400">
-                  {buteco.cidade}
-                </span>
+              <li key={buteco.slug} className="flex items-center gap-3">
+                <Carimbo
+                  nome={buteco.nome}
+                  bairro={buteco.bairro ?? undefined}
+                  size="xs"
+                  color="mostarda"
+                />
+                <div>
+                  <Link
+                    href={`/butecos/${buteco.slug}`}
+                    className="font-body font-medium text-ink transition hover:text-primary"
+                  >
+                    {buteco.nome}
+                  </Link>
+                  <p className="font-mono text-[11px] text-ink-muted">{buteco.cidade}</p>
+                </div>
               </li>
             ))}
           </ul>
@@ -44,22 +62,42 @@ export default async function MinhaContaPage() {
       </section>
 
       <section>
-        <h2 className="text-xl font-semibold mb-4 dark:text-zinc-100">Visitados</h2>
+        <h2 className="mb-4 font-display text-[20px] font-semibold text-ink">
+          Butecos que você conheceu
+        </h2>
         {user.visitas.length === 0 ? (
-          <p className="text-zinc-500 dark:text-zinc-400">Nenhuma visita registrada.</p>
+          <div className="text-center">
+            <p className="font-body text-[14px] text-ink-muted">
+              Nenhum carimbo ainda — bora conhecer um buteco?
+            </p>
+            <Link
+              href="/butecos"
+              className="mt-4 inline-flex items-center justify-center rounded-full bg-primary px-5 py-2.5 font-body text-[13px] font-medium text-primary-ink transition hover:bg-terracota-600"
+            >
+              Ver botecos
+            </Link>
+          </div>
         ) : (
-          <ul className="space-y-2">
+          <ul className="space-y-3">
             {user.visitas.map(({ buteco, visitadoEm }) => (
-              <li key={buteco.slug}>
-                <a
-                  href={`/butecos/${buteco.slug}`}
-                  className="font-medium hover:underline dark:text-zinc-200"
-                >
-                  {buteco.nome}
-                </a>
-                <span className="text-zinc-500 text-sm ml-2 dark:text-zinc-400">
-                  {visitadoEm.toLocaleDateString("pt-BR")}
-                </span>
+              <li key={buteco.slug} className="flex items-center gap-3">
+                <Carimbo
+                  nome={buteco.nome}
+                  bairro={buteco.bairro ?? undefined}
+                  size="xs"
+                  color="tinto"
+                />
+                <div>
+                  <Link
+                    href={`/butecos/${buteco.slug}`}
+                    className="font-body font-medium text-ink transition hover:text-primary"
+                  >
+                    {buteco.nome}
+                  </Link>
+                  <p className="font-mono text-[11px] text-ink-muted">
+                    {visitadoEm.toLocaleDateString("pt-BR")}
+                  </p>
+                </div>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Resumo

- Login: título "Entre e continue o rolê", benefícios atualizados (Favoritos + Carimbos), logo-mark.svg no ícone, aplica font-display/font-body/font-mono em todos os elementos
- Minha Conta: Favoritos com `Carimbo` xs mostarda; seção "Butecos que você conheceu" (era "Visitados") com `Carimbo` xs tinto + data visitada em font-mono; estados vazios com copy botequeiro e CTA para /butecos; usa `Link` no lugar de `<a>`

## Plano de testes

- [ ] `npm run test` — 92 testes passando
- [ ] `npm run lint` — sem erros
- [ ] `npm run build` — build OK

Closes #94
Refs #88