### PR TITLE
fix: corrige tipos TypeScript em testes e override do deepmerge-ts

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -2,6 +2,8 @@
 
 # This is NOT the Next.js you know
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
 
 <!-- END:nextjs-agent-rules -->

--- a/apps/web/app/(public)/butecos/[slug]/__tests__/page.test.tsx
+++ b/apps/web/app/(public)/butecos/[slug]/__tests__/page.test.tsx
@@ -48,7 +48,7 @@ jest.mock("@/components/butecos/buteco-action-panel", () => ({
 
 const getButecoBySlugMock = getButecoBySlug as jest.Mock;
 const getButecoActionStateMock = getButecoActionState as jest.Mock;
-const notFoundMock = notFound as jest.Mock;
+const notFoundMock = notFound as unknown as jest.Mock;
 
 describe("ButecoPage", () => {
   beforeEach(() => {

--- a/apps/web/lib/__tests__/detail-actions.test.ts
+++ b/apps/web/lib/__tests__/detail-actions.test.ts
@@ -21,7 +21,7 @@ import { buildButecoLoginHref, getButecoActionState } from "@/lib/detail-actions
 
 const cookiesMock = cookies as jest.Mock;
 const authMock = auth as jest.Mock;
-const prismaMock = prisma as {
+const prismaMock = prisma as unknown as {
   user: { findUnique: jest.Mock };
   favorito: { findUnique: jest.Mock };
   visita: { findUnique: jest.Mock };

--- a/apps/web/lib/__tests__/use-geolocalizacao.test.ts
+++ b/apps/web/lib/__tests__/use-geolocalizacao.test.ts
@@ -23,8 +23,10 @@ function makePosition(latitude: number, longitude: number): GeolocationPosition 
       latitude,
       longitude,
       speed: null,
+      toJSON: () => ({}),
     },
     timestamp: Date.now(),
+    toJSON: () => ({}),
   };
 }
 

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@babel/core': ^7.29.6
   '@hono/node-server': '>=1.19.13'
   brace-expansion: '>=1.1.18'
+  deepmerge-ts: '>=8.0.0'
   fast-uri: ^3.1.2
   hono: '>=4.12.25'
   js-yaml: '>=4.3.1'
@@ -1890,8 +1891,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   deepmerge@4.3.1:
@@ -4710,7 +4711,7 @@ snapshots:
   '@prisma/config@7.9.1':
     dependencies:
       c12: 3.3.4
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       effect: 3.20.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -5766,7 +5767,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   deepmerge@4.3.1: {}
 

--- a/apps/web/pnpm-workspace.yaml
+++ b/apps/web/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ overrides:
   "@babel/core": "^7.29.6"
   "@hono/node-server": ">=1.19.13"
   "brace-expansion": ">=1.1.18"
+  "deepmerge-ts": ">=8.0.0"
   fast-uri: "^3.1.2"
   hono: ">=4.12.25"
   js-yaml: ">=4.3.1"


### PR DESCRIPTION
Aplica as correcoes de tipagem e override de dependencias para o build na Vercel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project guidance for improved monorepo and dependency documentation handling.
  * Required a secure, updated version of a supporting package.

* **Tests**
  * Improved test compatibility with current Next.js and mocking types.
  * Enhanced geolocation test fixtures to match expected browser behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->