### PR TITLE
fix(sitemap): gerar por request em vez de no build

### DIFF
--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,6 +1,13 @@
 import type { MetadataRoute } from "next";
 import { listPublicButecoEntriesForSitemap } from "@/lib/public-butecos";
 
+// Gerado a cada request, nao no build. Sem isto o Next tenta pre-renderizar
+// /sitemap.xml durante `next build` e o build passa a exigir acesso ao banco
+// de producao -- que existia quando o banco era o Supabase (internet
+// publica), mas nao existe desde a migracao pro Postgres local, que so
+// responde na rede docker interna. O build quebrava com DatabaseNotReachable.
+export const dynamic = "force-dynamic";
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = new URL(process.env.NEXTAUTH_URL ?? "https://onde-tem-buteco.vercel.app");
   const butecos = await listPublicButecoEntriesForSitemap();


### PR DESCRIPTION
## Problema

`app/sitemap.ts` consulta o banco. Como não declara `dynamic`, o Next
tenta pré-renderizar `/sitemap.xml` durante `next build` — e o build
passa a exigir acesso ao banco de produção.

Isso funcionava quando o banco era o Supabase (internet pública). Depois
da migração para o Postgres local, que só responde na rede docker
interna, o build quebra:

```
DriverAdapterError: DatabaseNotReachable
    at async i (app/sitemap.ts:6:19)
Export encountered an error on /sitemap.xml/route: /sitemap.xml, exiting the build.
```

A imagem em produção é de 21/08, anterior à migração, então o problema
estava latente: só apareceria no próximo deploy.

## Solução

`export const dynamic = "force-dynamic"` no sitemap.

- O build volta a ser hermético — não depende mais de banco.
- O sitemap passa a refletir os dados a cada request, em vez de congelar
  o estado do momento do build.

Verificado: build completo passa (`docker buildx build --target builder`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RqDtA6LD5VF1hncdVvX3B