### PR TITLE
perf: imagem de 1.82GB para 310MB (output standalone)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -34,11 +34,16 @@ FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 RUN corepack enable
-COPY --from=builder --chown=node:node /app ./
+# So o que o standalone precisa, em vez da arvore inteira do builder.
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+COPY --from=builder --chown=node:node /app/public ./public
 # Roda como non-root (auditoria 2026-08-21). `node` (uid 1000) ja vem na
 # imagem. O runner recebe a arvore inteira do builder, entao o chown do
 # COPY cobre tudo -- inclusive .next/cache, que o `next start` precisa
 # gravavel em runtime pra ISR.
 USER node
 EXPOSE 3000
-CMD ["pnpm", "start"]
+# O standalone traz seu proprio server.js; `pnpm start` chamaria o next CLI,
+# que nao existe mais na imagem enxuta.
+CMD ["node", "server.js"]

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,8 +6,22 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.resolve(__dirname),
   },
+  // `standalone`: o Next emite um bundle com so as dependencias rastreadas.
+  // Sem isso o runner copiava a arvore inteira do builder -- node_modules com
+  // dev deps, codigo-fonte e .next/cache -- e a imagem tinha 1.82GB.
+  output: "standalone",
+  // Necessario porque o rastreamento nao enxerga o client gerado pelo Prisma
+  // (escrito em build-time, sem import estatico).
   outputFileTracingIncludes: {
-    "*": ["./app/generated/prisma/**/*"],
+    "*": [
+      "./app/generated/prisma/**/*",
+      // Os chunks compilados referenciam @swc/helpers pelo caminho ANINHADO
+      // dentro do diretorio do next no .pnpm (link de peer dependency que o
+      // rastreamento nao segue). Sem esta linha a imagem sobe e morre com
+      // "Cannot find module .../next@.../node_modules/@swc/helpers/...".
+      // Glob no lugar da versao pra nao quebrar no proximo bump do next.
+      "./node_modules/.pnpm/next@*/node_modules/@swc/helpers/**/*",
+    ],
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## O problema

O estágio `runner` copiava a árvore inteira do builder:

```dockerfile
COPY --from=builder --chown=node:node /app ./     # 1,21GB numa camada só
```

Isso leva `node_modules` completo (com dependências de desenvolvimento), o código-fonte e o `.next/cache` para a imagem final. Resultado: **1,82 GB**.

## A mudança

`output: "standalone"` no `next.config.ts`, e o runner passa a copiar só `.next/standalone`, `.next/static` e `public`.

**1,82 GB → 310 MB** (5,9× menor).

### A parte não óbvia

O rastreamento do `standalone` não segue link simbólico de peer dependency. Os chunks compilados referenciam `@swc/helpers` pelo caminho **aninhado dentro do diretório do `next` no `.pnpm`**, e esse arquivo ficava de fora — a imagem subia e morria com `Cannot find module`.

Tentei antes `node-linker=hoisted` por `.npmrc` e por variável de ambiente; **o pnpm 11 ignora as duas** (desde a v10 a configuração própria dele mora em `pnpm-workspace.yaml`). E mesmo com hoisting ativo o erro persistia, porque o caminho está gravado no bundle.

A solução é uma entrada de `outputFileTracingIncludes` apontando para o caminho aninhado, com glob na versão do next para não quebrar no próximo bump.

## Verificação

Imagem construída e rodada em paralelo à produção, comparando byte a byte:

| rota | imagem nova | produção |
|---|---|---|
| `/` | 200 / 160156 | 200 / 160156 |
| `/sitemap.xml` | 200 / 142392 | 200 / 142392 |
| `/api/auth/providers` | 200 / 208 | 200 / 208 |
| `/butecos` | 200 / 1551563 | 200 / 1551563 |

Zero erro no log, DSN do Sentry presente no bundle, container roda como `node`.

O mesmo já foi aplicado no `ludotrace` (1,59 GB → 309 MB), onde o deploy caiu de ~6 min para 1,8 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RqDtA6LD5VF1hncdVvX3B