### PR TITLE
build: adicionar .dockerignore

### DIFF
--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,29 @@
+# Sem este arquivo, o `COPY . .` do estagio builder despeja o node_modules da
+# maquina por cima do que veio do estagio `deps`. As duas arvores se misturam e
+# o build da imagem passa a depender do estado de quem o roda.
+#
+# Na VPS nunca aparece: /srv/onde-tem-buteco nao tem node_modules, o build so
+# acontece dentro do Docker. Aparece em qualquer maquina ou runner que rode
+# `pnpm install` antes -- o `pnpm run build` dentro da imagem detecta o
+# node_modules inconsistente, decide purga-lo e aborta por nao ter TTY
+# (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY). Foi exatamente o que quebrou a
+# primeira execucao de CI do ludotrace, que tem o mesmo formato de Dockerfile.
+node_modules
+.next
+
+# Nunca deixar segredo entrar no contexto: as connection strings entram por
+# secret mount justamente pra nao ficarem no historico da imagem, e um .env
+# solto no contexto anularia isso.
+.env
+.env.*
+
+.git
+.gitignore
+coverage
+test-results
+playwright-report
+e2e
+Dockerfile
+.dockerignore
+npm-debug.log*
+*.tsbuildinfo


### PR DESCRIPTION
O repositório não tinha `.dockerignore`, e o Dockerfile usa `COPY . .`. O
resultado é que o `node_modules` da máquina cai por cima do que veio do estágio
`deps`: as duas árvores se misturam e o build da imagem passa a depender do
estado de quem o roda.

**Na VPS isso nunca aparece**, porque `/srv/onde-tem-buteco` não tem
`node_modules` — o build só acontece dentro do Docker. Aparece em qualquer
máquina ou runner que rode `pnpm install` antes: o `pnpm run build` dentro da
imagem detecta o `node_modules` inconsistente, decide purgá-lo e aborta por não
ter TTY (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`).

Foi exatamente o que quebrou a primeira execução de CI do `ludotrace`, que tem
o mesmo formato de Dockerfile. Este app ainda não tem CI, então a bomba está
armada e não estourou.

Também tira `.git`, `.next` e artefatos de teste do contexto, e barra `.env` —
as connection strings entram por secret mount justamente para não ficarem no
histórico da imagem.

## Verificação

Build do estágio `builder` com os secrets reais: `✓ Compiled successfully`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RqDtA6LD5VF1hncdVvX3B